### PR TITLE
spec. add python2-devel dependency

### DIFF
--- a/nethvoice-report.spec
+++ b/nethvoice-report.spec
@@ -16,6 +16,7 @@ Requires:	redis
 
 BuildRequires: 	perl
 BuildRequires: 	nethserver-devtools
+BuildRequires: 	python2-devel
 
 %description
 Queue and CDR/Costs reports


### PR DESCRIPTION
Correctly expand 'python2_sitelib' macro for collectd plugin