### PR TITLE
Redirect HTTPS and change URL

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -36,6 +36,7 @@ event_actions('nethvoice-report-update', qw(
 
 event_templates('nethvoice-report-update', qw(
 	/opt/nethvoice-report/api/conf.json
+    /etc/httpd/conf.d/default-virtualhost.inc
 ));
 
 event_services('nethvoice-report-update', qw(

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/50nethvoice_report
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/50nethvoice_report
@@ -1,0 +1,6 @@
+#
+# 50nethvoice_report
+#
+RewriteEngine On
+RewriteCond %\{HTTPS\} !=on
+RewriteRule ^/pbx-report(/.*)?$  https://%\{HTTP_HOST\}/pbx-report$1  [L,R=301]

--- a/root/etc/httpd/conf.d/nethvoice-report.conf
+++ b/root/etc/httpd/conf.d/nethvoice-report.conf
@@ -1,11 +1,11 @@
-Alias /nethvoice-report /opt/nethvoice-report/ui
+Alias /pbx-report /opt/pbx-report/ui
 
-<Location /nethvoice-report/api/>
+<Location /pbx-report/api/>
     Require all granted
     ProxyPass http://127.0.0.1:8585/
     ProxyPassReverse http://127.0.0.1:8585/
 </Location>
 
-<Directory /opt/nethvoice-report/ui/>
+<Directory /opt/pbx-report/ui/>
     Require all granted
 </Directory>

--- a/root/etc/httpd/conf.d/nethvoice-report.conf
+++ b/root/etc/httpd/conf.d/nethvoice-report.conf
@@ -2,8 +2,8 @@ Alias /pbx-report /opt/pbx-report/ui
 
 <Location /pbx-report/api/>
     Require all granted
-    ProxyPass http://127.0.0.1:8585/
-    ProxyPassReverse http://127.0.0.1:8585/
+    ProxyPass http://127.0.0.1:8585/api/
+    ProxyPassReverse http://127.0.0.1:8585/api/
 </Location>
 
 <Directory /opt/pbx-report/ui/>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -42,8 +42,8 @@ new Vue({
   router,
   i18n,
   created: function () {
-    this.apiEndpoint = "192.168.5.82:8585/api"; //window.location.host ////
-    this.apiScheme = "http://"; //window.location.protocol + "//"; ////
+    this.apiEndpoint = window.location.host + window.location.pathname + "api";
+    this.apiScheme = window.location.protocol + "//";
     this.currentLocale = langConf.locale;
     this.currentView = "";
     this.config = window.CONFIG;


### PR DESCRIPTION
- use a neutral URL to avoid conflicts with rebranded installations
- force HTTPS access

