### PR TITLE
spec. mark user_authorizations.json as config file

### DIFF
--- a/nethvoice-report.spec
+++ b/nethvoice-report.spec
@@ -59,12 +59,13 @@ cp collectd/asterisk_stats.conf %{buildroot}/etc/collectd.d/
     --file /opt/nethvoice-report/api/user_authorizations.json 'attr(0664,asterisk,asterisk)' \
     --file /opt/nethvoice-report/api/api 'attr(0755,asterisk,asterisk)' \
     --file /opt/nethvoice-report/tasks/tasks 'attr(0755,asterisk,asterisk)' \
-    > %{name}-%{version}-filelist
+    | grep -v /opt/nethvoice-report/api/user_authorizations.json > %{name}-%{version}-filelist
 cat %{name}-%{version}-filelist
 
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
 %dir %{_nseventsdir}/%{name}-update
+%config(noreplace) /opt/nethvoice-report/api/user_authorizations.json
 
 %doc COPYING
 


### PR DESCRIPTION
Previously, the configuration file was erased after the package update