### PR TITLE
report-conf: do not execute task jobs

### DIFF
--- a/root/etc/e-smith/events/actions/nethvoice-report-conf
+++ b/root/etc/e-smith/events/actions/nethvoice-report-conf
@@ -37,9 +37,5 @@ password=$(perl -e "use NethServer::Password; print NethServer::Password::store(
 # flush privileges
 /usr/bin/mysql --defaults-file=/root/.my.cnf -e "FLUSH PRIVILEGES"
 
-# precalculate some data to use report immediately
-/opt/nethvoice-report/tasks/tasks phonebook
-/opt/nethvoice-report/tasks/tasks values
-
 # expand user auth file
 scl enable rh-php56 /var/lib/asterisk/bin/retrieve_conf


### PR DESCRIPTION
The tasks could hang the update event for long time.
The UI can wait the execution of nightly jobs.