### PR TITLE
Time filter enhancements

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -42,14 +42,14 @@ func main() {
 	configuration.Init(ConfigFilePtr)
 
 	// disable log to stdout when running in release mode
-	if (gin.Mode() == gin.ReleaseMode) {
+	if gin.Mode() == gin.ReleaseMode {
 		gin.DefaultWriter = ioutil.Discard
 	}
 
 	// init routers
 	router := gin.Default()
 
-	// cors //// remove before release
+	// cors //// use configuration / env variable
 	// router.Use(cors.Default())
 	corsConf := cors.DefaultConfig()
 	corsConf.AllowHeaders = []string{"Authorization", "Content-Type"}

--- a/root/opt/nethvoice-report/api/queries/performance/default/2_table_qos.sql
+++ b/root/opt/nethvoice-report/api/queries/performance/default/2_table_qos.sql
@@ -12,8 +12,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -36,8 +36,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -57,8 +57,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -78,8 +78,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -102,8 +102,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -123,8 +123,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -144,8 +144,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -168,8 +168,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -189,8 +189,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -210,8 +210,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -234,8 +234,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -255,8 +255,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -276,8 +276,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -300,8 +300,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -321,8 +321,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -342,8 +342,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -366,8 +366,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -387,8 +387,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -408,8 +408,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -432,8 +432,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -453,8 +453,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -474,8 +474,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -498,8 +498,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -519,8 +519,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -540,8 +540,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -564,8 +564,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -585,8 +585,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -606,8 +606,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -630,8 +630,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -651,8 +651,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -672,8 +672,8 @@ FROM   (SELECT "total"                           AS responseTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"

--- a/root/opt/nethvoice-report/api/queries/performance/default/3_table_talkTime.sql
+++ b/root/opt/nethvoice-report/api/queries/performance/default/3_table_talkTime.sql
@@ -12,8 +12,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -36,8 +36,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -57,8 +57,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -78,8 +78,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -102,8 +102,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -123,8 +123,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -144,8 +144,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -168,8 +168,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -189,8 +189,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -210,8 +210,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -234,8 +234,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -255,8 +255,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -276,8 +276,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -300,8 +300,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -321,8 +321,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -342,8 +342,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -366,8 +366,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -387,8 +387,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -408,8 +408,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -432,8 +432,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -453,8 +453,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -474,8 +474,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -498,8 +498,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -519,8 +519,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -540,8 +540,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -564,8 +564,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -585,8 +585,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -606,8 +606,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -630,8 +630,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -651,8 +651,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -672,8 +672,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -696,8 +696,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -717,8 +717,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -738,8 +738,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -762,8 +762,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -783,8 +783,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -804,8 +804,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -828,8 +828,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -849,8 +849,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -870,8 +870,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -894,8 +894,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -915,8 +915,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -936,8 +936,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -960,8 +960,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -981,8 +981,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1002,8 +1002,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1026,8 +1026,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1047,8 +1047,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1068,8 +1068,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1092,8 +1092,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1113,8 +1113,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1134,8 +1134,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1158,8 +1158,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1179,8 +1179,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"
@@ -1200,8 +1200,8 @@ FROM   (SELECT "total"                           AS talkTime£label,
                         AND date_format(timestamp_in, "%Y-%m") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m") <= "{{ .Time.Interval.End }}"
                         {{ else if eq .Time.Group "week" }}
-                        AND date_format(timestamp_in, "%Y-%u") >= "{{ .Time.Interval.Start }}"
-                        AND date_format(timestamp_out, "%Y-%u") <= "{{ .Time.Interval.End }}"
+                        AND date_format(timestamp_in, "%x-W%v") >= "{{ .Time.Interval.Start }}"
+                        AND date_format(timestamp_out, "%x-W%v") <= "{{ .Time.Interval.End }}"
                         {{ else }}
                         AND date_format(timestamp_in, "%Y-%m-%d") >= "{{ .Time.Interval.Start }}"
                         AND date_format(timestamp_out, "%Y-%m-%d") <= "{{ .Time.Interval.End }}"

--- a/root/opt/nethvoice-report/api/views/dashboard_call_byagent.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_call_byagent.sql
@@ -52,7 +52,7 @@ ORDER BY
 
 CREATE TABLE dashboard_call_byagent_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     IF(
         locate('@', agent) > 0,
         substring_index(substring_index(agent, '/', -2), '@', 1),

--- a/root/opt/nethvoice-report/api/views/dashboard_call_lost.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_call_lost.sql
@@ -64,7 +64,7 @@ DROP TABLE IF EXISTS distribution_hour_lost_week_60;
 
 CREATE TABLE distribution_hour_lost_week_60 AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     qdescr,
     Date_format(

--- a/root/opt/nethvoice-report/api/views/dashboard_call_uniqcid.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_call_uniqcid.sql
@@ -36,7 +36,7 @@ ORDER BY
 
 CREATE TABLE dashboard_call_uniqcid_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     qdescr,
     Count(DISTINCT cid) AS total

--- a/root/opt/nethvoice-report/api/views/data_agent.sql
+++ b/root/opt/nethvoice-report/api/views/data_agent.sql
@@ -125,7 +125,7 @@ CREATE TABLE data_agent_week AS
                  Max(duration)                                  AS max_duration, 
                  Min(Nullif(duration, 0))                       AS min_duration, 
                  Avg(duration)                                  AS avg_duration, 
-                 Date_format(From_unixtime(timestamp_in), '%Y-%u') AS period 
+                 Date_format(From_unixtime(timestamp_in), '%x-W%v') AS period 
           FROM   report_queue_agents 
           GROUP  BY agent, 
                     period, 
@@ -140,7 +140,7 @@ CREATE TABLE data_agent_week AS
                                                 AS pause, 
                       Count(DISTINCT( Date(From_unixtime(timestamp_in)) )) 
                                                 AS logon, 
-                      Date_format(From_unixtime(timestamp_in), '%Y-%u') 
+                      Date_format(From_unixtime(timestamp_in), '%x-W%v') 
                                                 AS period 
                FROM   agentsessions 
                GROUP  BY agent, 

--- a/root/opt/nethvoice-report/api/views/data_caller.sql
+++ b/root/opt/nethvoice-report/api/views/data_caller.sql
@@ -141,7 +141,7 @@ ORDER BY
 
 CREATE TABLE data_caller_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS `period`,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS `period`,
     cid,
     qname,
     qdescr,

--- a/root/opt/nethvoice-report/api/views/data_ivr.sql
+++ b/root/opt/nethvoice-report/api/views/data_ivr.sql
@@ -50,7 +50,7 @@ ORDER BY
 
 CREATE TABLE data_ivr_week AS
 SELECT
-    DATE_FORMAT(time, "%Y-%u") AS period,
+    DATE_FORMAT(time, "%x-W%v") AS period,
     data3 AS ivr_id,
     data4 AS ivr_name,
     data2 AS choice,

--- a/root/opt/nethvoice-report/api/views/data_summary_agent.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_agent.sql
@@ -70,7 +70,7 @@ GROUP BY
 
 CREATE TABLE data_summary_agent_week AS
 SELECT
-       Date_format(calldate, "%Y-%u") AS period,
+       Date_format(calldate, "%x-W%v") AS period,
        src AS agentNum,
        (
               SELECT

--- a/root/opt/nethvoice-report/api/views/data_summary_exitempty.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_exitempty.sql
@@ -58,7 +58,7 @@ ORDER BY
 
 CREATE TABLE data_summary_exitempty_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_exitkey.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_exitkey.sql
@@ -58,7 +58,7 @@ ORDER BY
 
 CREATE TABLE data_summary_exitkey_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_failed.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_failed.sql
@@ -64,7 +64,7 @@ ORDER BY
 
 CREATE TABLE data_summary_failed_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_full.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_full.sql
@@ -42,7 +42,7 @@ ORDER BY
 
 CREATE TABLE data_summary_full_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_good.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_good.sql
@@ -58,7 +58,7 @@ ORDER BY
 
 CREATE TABLE data_summary_good_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_joinempty.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_joinempty.sql
@@ -42,7 +42,7 @@ ORDER BY
 
 CREATE TABLE data_summary_joinempty_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_null.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_null.sql
@@ -48,7 +48,7 @@ ORDER BY
 
 CREATE TABLE data_summary_null_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/data_summary_timeout.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_timeout.sql
@@ -58,7 +58,7 @@ ORDER BY
 
 CREATE TABLE data_summary_timeout_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        Count(DISTINCT cid) AS uniqCid,
        Count(id) AS num,

--- a/root/opt/nethvoice-report/api/views/distribution_geographic.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_geographic.sql
@@ -58,7 +58,7 @@ ORDER BY
 
 CREATE TABLE distribution_geo_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        prefisso,

--- a/root/opt/nethvoice-report/api/views/distribution_hour_agent.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_agent.sql
@@ -344,7 +344,7 @@ DROP TABLE IF EXISTS distribution_hour_agent_week_60;
 
 CREATE TABLE distribution_hour_agent_week_10 AS
 SELECT
-       Date_format(calldate, "%Y-%u") AS period,
+       Date_format(calldate, "%x-W%v") AS period,
        src AS agentNum,
        (
               SELECT
@@ -384,7 +384,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_agent_week_15 AS
 SELECT
-       Date_format(calldate, "%Y-%u") AS period,
+       Date_format(calldate, "%x-W%v") AS period,
        src AS agentNum,
        (
               SELECT
@@ -424,7 +424,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_agent_week_30 AS
 SELECT
-       Date_format(calldate, "%Y-%u") AS period,
+       Date_format(calldate, "%x-W%v") AS period,
        src AS agentNum,
        (
               SELECT
@@ -464,7 +464,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_agent_week_60 AS
 SELECT
-       Date_format(calldate, "%Y-%u") AS period,
+       Date_format(calldate, "%x-W%v") AS period,
        src AS agentNum,
        (
               SELECT

--- a/root/opt/nethvoice-report/api/views/distribution_hour_exitempty.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_exitempty.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_exitempty_week_60;
 
 CREATE TABLE distribution_hour_exitempty_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitempty_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitempty_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitempty_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_exitkey.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_exitkey.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_exitkey_week_60;
 
 CREATE TABLE distribution_hour_exitkey_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitkey_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitkey_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_exitkey_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_failed.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_failed.sql
@@ -264,7 +264,7 @@ DROP TABLE IF EXISTS distribution_hour_failed_week_60;
 
 CREATE TABLE distribution_hour_failed_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -294,7 +294,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_failed_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -324,7 +324,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_failed_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -354,7 +354,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_failed_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_full.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_full.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_full_week_60;
 
 CREATE TABLE distribution_hour_full_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_full_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_full_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_full_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_good.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_good.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_good_week_60;
 
 CREATE TABLE distribution_hour_good_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_good_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_good_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_good_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_ivr.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_ivr.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_ivr_week_60;
 
 CREATE TABLE distribution_hour_ivr_week_10 AS
 SELECT
-       Date_format(time, "%Y-%u") AS period,
+       Date_format(time, "%x-W%v") AS period,
        Date_format(
               Sec_to_time(
                      Time_to_sec(time) - Time_to_sec(time) % (10 * 60)
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_ivr_week_15 AS
 SELECT
-       Date_format(time, "%Y-%u") AS period,
+       Date_format(time, "%x-W%v") AS period,
        Date_format(
               Sec_to_time(
                      Time_to_sec(time) - Time_to_sec(time) % (15 * 60)
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_ivr_week_30 AS
 SELECT
-       Date_format(time, "%Y-%u") AS period,
+       Date_format(time, "%x-W%v") AS period,
        Date_format(
               Sec_to_time(
                      Time_to_sec(time) - Time_to_sec(time) % (30 * 60)
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_ivr_week_60 AS
 SELECT
-       Date_format(time, "%Y-%u") AS period,
+       Date_format(time, "%x-W%v") AS period,
        Date_format(
               Sec_to_time(
                      Time_to_sec(time) - Time_to_sec(time) % (60 * 60)

--- a/root/opt/nethvoice-report/api/views/distribution_hour_joinempty.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_joinempty.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_joinempty_week_60;
 
 CREATE TABLE distribution_hour_joinempty_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_joinempty_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_joinempty_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_joinempty_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_null.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_null.sql
@@ -264,7 +264,7 @@ DROP TABLE IF EXISTS distribution_hour_null_week_60;
 
 CREATE TABLE distribution_hour_null_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -294,7 +294,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_null_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -324,7 +324,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_null_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -354,7 +354,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_null_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_timeout.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_timeout.sql
@@ -256,7 +256,7 @@ DROP TABLE IF EXISTS distribution_hour_timeout_week_60;
 
 CREATE TABLE distribution_hour_timeout_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -285,7 +285,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_timeout_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -314,7 +314,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_timeout_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -343,7 +343,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_timeout_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/distribution_hour_total.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_total.sql
@@ -240,7 +240,7 @@ DROP TABLE IF EXISTS distribution_hour_total_week_60;
 
 CREATE TABLE distribution_hour_total_week_10 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -267,7 +267,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_total_week_15 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -294,7 +294,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_total_week_30 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(
@@ -321,7 +321,7 @@ ORDER BY
 
 CREATE TABLE distribution_hour_total_week_60 AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Date_format(

--- a/root/opt/nethvoice-report/api/views/graph_agent.sql
+++ b/root/opt/nethvoice-report/api/views/graph_agent.sql
@@ -50,7 +50,7 @@ ORDER BY
 
 CREATE TABLE graph_agent_answer_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     qdescr,
     agent,
@@ -142,7 +142,7 @@ ORDER BY
 
 CREATE TABLE graph_agent_noanswer_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     qdescr,
     agent,

--- a/root/opt/nethvoice-report/api/views/graph_load.sql
+++ b/root/opt/nethvoice-report/api/views/graph_load.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE graph_load_total_week AS
 SELECT
-       Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+       Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
        qname,
        qdescr,
        Count(id) AS total

--- a/root/opt/nethvoice-report/api/views/performance_exitempty.sql
+++ b/root/opt/nethvoice-report/api/views/performance_exitempty.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_exitempty_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_exitkey.sql
+++ b/root/opt/nethvoice-report/api/views/performance_exitkey.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_exitkey_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_failed.sql
+++ b/root/opt/nethvoice-report/api/views/performance_failed.sql
@@ -44,7 +44,7 @@ ORDER BY
 
 CREATE TABLE performance_failed_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_full.sql
+++ b/root/opt/nethvoice-report/api/views/performance_full.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_full_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_good.sql
+++ b/root/opt/nethvoice-report/api/views/performance_good.sql
@@ -44,7 +44,7 @@ ORDER BY
 
 CREATE TABLE performance_good_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_joinempty.sql
+++ b/root/opt/nethvoice-report/api/views/performance_joinempty.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_joinempty_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_null.sql
+++ b/root/opt/nethvoice-report/api/views/performance_null.sql
@@ -44,7 +44,7 @@ ORDER BY
 
 CREATE TABLE performance_null_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_processed.sql
+++ b/root/opt/nethvoice-report/api/views/performance_processed.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_processed_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_timeout.sql
+++ b/root/opt/nethvoice-report/api/views/performance_timeout.sql
@@ -38,7 +38,7 @@ ORDER BY
 
 CREATE TABLE performance_timeout_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Count(id) AS count
 FROM

--- a/root/opt/nethvoice-report/api/views/performance_wait_duration.sql
+++ b/root/opt/nethvoice-report/api/views/performance_wait_duration.sql
@@ -46,7 +46,7 @@ GROUP BY
 
 CREATE TABLE performance_wait_duration_week AS
 SELECT
-    Date_format(From_unixtime(timestamp_in), "%Y-%u") AS period,
+    Date_format(From_unixtime(timestamp_in), "%x-W%v") AS period,
     qname,
     Max(hold) AS max_hold,
     Min(hold) AS min_hold,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4761,6 +4761,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
       "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
+    "date-format-parse": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/date-format-parse/-/date-format-parse-0.2.5.tgz",
+      "integrity": "sha512-PzvB3p9bTxrGQbz3ZlO/kxgXzKZhMo4l0OQfPqVYjuwixHRS9yHH6cUJI9JG2Hh6iUQgh17T7w95lzQ131dS/g=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -10070,11 +10075,6 @@
         "ts-pnp": "^1.1.6"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "portal-vue": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
@@ -13215,16 +13215,6 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
-    "v-calendar": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-1.0.8.tgz",
-      "integrity": "sha512-2st0wvSM7oGTOQixVMFHAEPjGBWEJmAhBDE6NYR5MB9Owe1d/pR5+A1OB+/HICXbuiKMjG8KzDpeySnPECddsw==",
-      "requires": {
-        "date-fns": "^2.6.0",
-        "lodash": "^4.17.15",
-        "popper.js": "^1.14.7"
-      }
-    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
@@ -13400,6 +13390,15 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue2-datepicker": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.7.0.tgz",
+      "integrity": "sha512-XB5slJZLXf3sbPIOMxjYPw2UlOI/utX4cHGQwGvRQqyiKzwpsGlPI6M3zUGw412Sm2tv2jMkXd9+k+yOSRf2OQ==",
+      "requires": {
+        "date-fns": "^2.0.1",
+        "date-format-parse": "^0.2.5"
+      }
     },
     "vue2-timepicker": {
       "version": "1.1.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,6 @@
     "portal-vue": "^2.1.7",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-vue": "^0.11.0",
-    "v-calendar": "^1.0.8",
     "vue": "^2.6.11",
     "vue-chartjs": "^3.5.1",
     "vue-i18n": "^8.21.1",
@@ -26,6 +25,7 @@
     "vue-resource": "^1.5.1",
     "vue-router": "^3.2.0",
     "vue-scrollto": "^2.19.1",
+    "vue2-datepicker": "^3.7.0",
     "vue2-timepicker": "^1.1.5"
   },
   "devDependencies": {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -272,4 +272,14 @@ export default {
 .report-data-not-available {
   width: 100%;
 }
+
+.error-color {
+  color: #9f3a38 !important;
+}
+
+.time-interval-error input {
+  background-color: #fff6f6 !important;
+  color: #9f3a38 !important;
+  border-color: #e0b4b4 !important;
+}
 </style>

--- a/ui/src/components/Filters.vue
+++ b/ui/src/components/Filters.vue
@@ -303,7 +303,7 @@
             icon="search"
             :disabled="loader.filter"
             class="mr-15"
-            >Search</sui-button
+            >{{ $t('command.search') }}</sui-button
           >
           <sui-button-group>
             <sui-button

--- a/ui/src/components/Filters.vue
+++ b/ui/src/components/Filters.vue
@@ -545,9 +545,6 @@ export default {
         this.filter.time.group = "day";
       }
     },
-    "filter.time.group": function () { ////
-      console.log("this.filter.time.group", this.filter.time.group); ////
-    },
     selectedSearch: function () {
       this.setFilterValuesFromSearch();
     },

--- a/ui/src/components/FixedBar.vue
+++ b/ui/src/components/FixedBar.vue
@@ -33,7 +33,7 @@
         <!-- label: time interval value -->
         <div class="ui label" v-if="activeFilters.time && activeFilters.time.interval">
           <span class="field">
-            {{$t('filter.dates_label')}}:
+            {{$t('filter.time_interval')}}:
           </span>
           <span class="value">
             {{`${activeFilters.time.interval.start} - ${activeFilters.time.interval.end}`}}

--- a/ui/src/filters/filters.js
+++ b/ui/src/filters/filters.js
@@ -27,7 +27,7 @@ var Filters = {
     },
     formatWeekDate(value, i18n) {
         // value: e.g. "2020-50"
-        const tokens = value.split("-");
+        const tokens = value.split("-W");
         const year = tokens[0];
         const weekNum = parseInt(tokens[1]);
         const firstDay = moment().year(year).week(weekNum).day(0).format('YYYY-MM-DD');

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -149,7 +149,9 @@
       "enter_name_for_saved_search": "Enter a name for your new saved search",
       "search_name_required": "Search name is required",
       "search_name_already_exist": "A search with the same name already exists",
-      "search_name_validation": "Search name must begin with a letter and contain only letters, spaces, numbers and dashes"
+      "search_name_validation": "Search name must begin with a letter and contain only letters, spaces, numbers and dashes",
+      "coming_soon": "Coming soon",
+      "cdr_not_available": "CDR & Cost report is not available yet, please come back later"
     },
     "pagination": {
       "page": "page",
@@ -267,6 +269,7 @@
       "save": "Save",
       "delete": "Delete",
       "cancel": "Cancel",
+      "search": "Search",
       "overwrite": "Overwrite",
       "close": "Close",
       "show_details": "Show details",

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -210,6 +210,8 @@
       "activity": "Activity",
       "load": "Load",
       "logonDays": "Logon days",
+      "logon": "Logon",
+      "afterwork": "Afterwork",
       "min_duration": "Min duration",
       "max_duration": "Max duration",
       "avg_duration": "Average duration",

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -4,6 +4,7 @@
       "group_by": "Group by",
       "saved_search": "Saved search",
       "time_interval": "Time interval",
+      "time_range": "Time range",
       "yesterday": "Yesterday",
       "last_week": "Last week",
       "last_month": "Last month",
@@ -11,8 +12,8 @@
       "week": "Week",
       "month": "Month",
       "year": "Year",
-      "dates_placeholder": "Select the date range",
-      "dates_label": "Date start/end",
+      "time_interval_start_placeholder": "Start date",
+      "time_interval_end_placeholder": "End date",
       "queues_label": "Queues",
       "groups_label": "Groups",
       "agents_label": "Agents",
@@ -37,7 +38,8 @@
       "area_code": "Area code",
       "district": "District",
       "province": "Province",
-      "region": "Region"
+      "region": "Region",
+      "time_start_end": "Time start/end"
     },
     "menu": {
       "queue": "Queue report",
@@ -144,7 +146,10 @@
       "office_hours_description": "Office hours are used to display report charts. Some charts plot data only inside office hours (e.g. Queue report > Graphs > Average duration)",
       "come_back_tomorrow": "Data not available, please come back tomorrow",
       "come_back_tomorrow_desc": "Report data are harvested and processed every night",
-      "enter_name_for_saved_search": "Enter a name for your new saved search"
+      "enter_name_for_saved_search": "Enter a name for your new saved search",
+      "search_name_required": "Search name is required",
+      "search_name_already_exist": "A search with the same name already exists",
+      "search_name_validation": "Search name must begin with a letter and contain only letters, spaces, numbers and dashes"
     },
     "pagination": {
       "page": "page",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -210,6 +210,8 @@
       "activity": "Activity",
       "load": "Load",
       "logonDays": "Logon days",
+      "logon": "Logon",
+      "afterwork": "Afterwork",
       "min_duration": "Min duration",
       "max_duration": "Max duration",
       "avg_duration": "Average duration",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -4,6 +4,7 @@
       "group_by": "Group by",
       "saved_search": "Saved search",
       "time_interval": "Time interval",
+      "time_range": "Time range",
       "yesterday": "Yesterday",
       "last_week": "Last week",
       "last_month": "Last month",
@@ -11,8 +12,8 @@
       "week": "Week",
       "month": "Month",
       "year": "Year",
-      "dates_placeholder": "Select the date range",
-      "dates_label": "Date start/end",
+      "time_interval_start_placeholder": "Start date",
+      "time_interval_end_placeholder": "End date",
       "queues_label": "Queues",
       "groups_label": "Groups",
       "agents_label": "Agents",
@@ -37,7 +38,8 @@
       "area_code": "Area code",
       "district": "District",
       "province": "Province",
-      "region": "Region"
+      "region": "Region",
+      "time_start_end": "Time start/end"
     },
     "menu": {
       "queue": "Queue report",
@@ -144,7 +146,10 @@
       "office_hours_description": "Office hours are used to display report charts. Some charts plot data only inside office hours (e.g. Queue report > Graphs > Average duration)",
       "come_back_tomorrow": "Data not available, please come back tomorrow",
       "come_back_tomorrow_desc": "Report data are harvested and processed every night",
-      "enter_name_for_saved_search": "Enter a name for your new saved search"
+      "enter_name_for_saved_search": "Enter a name for your new saved search",
+      "search_name_required": "Il nome della ricerca è obbligatorio",
+      "search_name_already_exist": "Esiste già una ricerca con questo nome",
+      "search_name_validation": "Il nome della ricerca deve iniziare con una lettera e contenere solamente lettere, spazi, numeri e trattini"
     },
     "pagination": {
       "page": "page",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -149,7 +149,9 @@
       "enter_name_for_saved_search": "Enter a name for your new saved search",
       "search_name_required": "Il nome della ricerca è obbligatorio",
       "search_name_already_exist": "Esiste già una ricerca con questo nome",
-      "search_name_validation": "Il nome della ricerca deve iniziare con una lettera e contenere solamente lettere, spazi, numeri e trattini"
+      "search_name_validation": "Il nome della ricerca deve iniziare con una lettera e contenere solamente lettere, spazi, numeri e trattini",
+      "coming_soon": "Coming soon",
+      "cdr_not_available": "Il report CDR & Cost non è ancora disponibile, torna più tardi"
     },
     "pagination": {
       "page": "page",
@@ -267,6 +269,7 @@
       "save": "Save",
       "delete": "Delete",
       "cancel": "Cancel",
+      "search": "Cerca",
       "overwrite": "Overwrite",
       "close": "Close",
       "show_details": "Show details",

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -2,7 +2,6 @@ import Vue from "vue";
 import VueResource from "vue-resource";
 import VueI18n from "vue-i18n";
 import PortalVue from "portal-vue";
-import VCalendar from 'v-calendar';
 import VueLodash from 'vue-lodash';
 import lodash from 'lodash';
 import VueScrollTo from 'vue-scrollto';
@@ -47,7 +46,6 @@ Vue.use(VueI18n);
 Vue.use(PortalVue);
 Vue.use(VueLodash, { name: 'ldsh', lodash: lodash });
 Vue.use(VueScrollTo)
-Vue.use(VCalendar);
 
 // configure i18n
 var langConf = languages.initLang();

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -34,9 +34,9 @@ var UtilService = {
         "data": {
           "summary": ["timeGroup", "time", "queue", "agent"],
           "agent": ["timeGroup", "time", "queue", "agent"],
-          "session": ["time", "queue", "reason", "agent"],
+          "session": ["time", "hour", "queue", "reason", "agent"],
           "caller": ["timeGroup", "time", "queue", "caller", "contactName"],
-          "call": ["time", "queue", "caller", "contactName", "agent", "result"],
+          "call": ["time", "hour", "queue", "caller", "contactName", "agent", "result"],
           "lost_call": ["timeGroup", "time", "queue", "caller", "contactName", "reason"],
           "ivr": ["timeGroup", "time", "ivr", "choice"]
         },

--- a/ui/src/views/CdrView.vue
+++ b/ui/src/views/CdrView.vue
@@ -1,6 +1,12 @@
 <template lang="html">
-<div>
-  CDR View
+<div class="ui placeholder segment report-data-not-available">
+  <div class="ui icon header">
+    <i class="wrench icon mg-bottom-sm"></i>
+    {{ $t("message.coming_soon") }}
+  </div>
+  <div class="inline">
+    {{ $t("message.cdr_not_available") }}
+  </div>
 </div>
 </template>
 


### PR DESCRIPTION
- Hour/minute selection filter for `data / session` and `data / call` views
- Only weeks, months or years can be selected in time filter if `Group by` is set to `Week`, `Month` or `Year` respectively
- Fix week numeration and grouping, according to  ISO-8601
- CDR Report: add "Coming Soon" message
- Add missing i18n strings

https://github.com/nethesis/dev/issues/5865