### PR TITLE
Fix nightly job execution order

### DIFF
--- a/root/etc/cron.d/nethvoice-report-tasks
+++ b/root/etc/cron.d/nethvoice-report-tasks
@@ -1,14 +1,8 @@
-# Launch queuereport update script at night
-59 22 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php
-
-# precalculate views for queries
-00 00 * * *	asterisk /opt/nethvoice-report/tasks/tasks views
+# Launch miners and tasks at night
+59 22 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php && /opt/nethvoice-report/tasks/tasks views && /opt/nethvoice-report/tasks/tasks queries
 
 # precalculate phonebook numbers during night
 10 00 * * *     asterisk /opt/nethvoice-report/tasks/tasks phonebook
 
 # precalculate filter values during night
 20 00 * * *     asterisk /opt/nethvoice-report/tasks/tasks values
-
-# precalculate queries during night
-30 00 * * *	asterisk /opt/nethvoice-report/tasks/tasks queries

--- a/root/etc/cron.d/nethvoice-report-tasks
+++ b/root/etc/cron.d/nethvoice-report-tasks
@@ -1,5 +1,5 @@
 # Launch queuereport update script at night
-01 23 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php
+59 22 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php
 
 # precalculate views for queries
 00 00 * * *	asterisk /opt/nethvoice-report/tasks/tasks views


### PR DESCRIPTION
- make sure the new miner is executed instead before the old one
- make sure `views` and `queues` tasks are executed in a specific order after mine execution
- `phonebook` and `values` tasks can be executed without any specific order