### PR TITLE
Fix time values for line/bar/table charts & other improvements

### DIFF
--- a/api/methods/settings.go
+++ b/api/methods/settings.go
@@ -33,15 +33,6 @@ import (
 )
 
 func GetSettings(c *gin.Context) {
-	// get current user
-	user := GetClaims(c)["id"].(string)
-
-	// check if user admin or API key
-	if user != "admin" && user != "X" {
-		c.JSON(http.StatusNotFound, gin.H{"message": "no settings found"})
-		return
-	}
-
 	// init cache connection
 	cacheConnection := cache.Instance()
 

--- a/ui/src/components/BarChart.vue
+++ b/ui/src/components/BarChart.vue
@@ -15,6 +15,12 @@ export default {
     data: {
       type: Array,
     },
+    officeHours: {
+      type: Object,
+    },
+    filterTimeSplit: {
+      type: Number,
+    },
     styles: {
       type: Object,
       default: function () {

--- a/ui/src/components/Filters.vue
+++ b/ui/src/components/Filters.vue
@@ -1105,6 +1105,18 @@ export default {
         return;
       }
 
+      // time group
+
+      if (!this.showFilterTimeGroup || !this.filter.time.group) {
+        this.filter.time.group = "day";
+      }
+
+      // time split
+
+      if (!this.showFilterTimeSplit || !this.filter.time.division) {
+        this.filter.time.division = "60";
+      }
+
       // save filter to local storage
       this.set(this.reportFilterStorageName, this.filter);
 

--- a/ui/src/components/FixedBar.vue
+++ b/ui/src/components/FixedBar.vue
@@ -121,7 +121,7 @@
           </span>
         </div>
         <!-- label: time split value -->
-        <div class="ui label" v-if="showFilterTimeSplit && activeFilters.time.division">
+        <div class="ui label" v-if="showFilterTimeSplit && activeFilters.time && activeFilters.time.division">
           <span class="field">
             {{$t('filter.time_split_label')}}:
           </span>

--- a/ui/src/components/FixedBar.vue
+++ b/ui/src/components/FixedBar.vue
@@ -209,9 +209,6 @@ export default {
       this.activeFilters = this.lodash.cloneDeep(this.filter)
       this.activeSelectedSearch = this.lodash.cloneDeep(this.selectedSearch)
     })
-    if (this.lodash.isEmpty(this.activeFilters)) {
-      this.$root.$emit("applyFilters")
-    }
     this.$nextTick(() => {
       window.addEventListener('scroll', this.scrollHandler, true)
     })

--- a/ui/src/components/FixedBar.vue
+++ b/ui/src/components/FixedBar.vue
@@ -245,8 +245,8 @@ export default {
   watch: {
     "activeFilters.time.interval": function () {
       if (this.activeFilters.time && this.activeFilters.time.interval) {
-        this.activeFilters.time.interval.start = this.formatDate(this.activeFilters.time.interval.start)
-        this.activeFilters.time.interval.end = this.formatDate(this.activeFilters.time.interval.end)
+        this.activeFilters.time.interval.start = this.$options.filters.formatDate(this.activeFilters.time.interval.start)
+        this.activeFilters.time.interval.end = this.$options.filters.formatDate(this.activeFilters.time.interval.end)
       }
     },
     "activeFilters.queues": function () {

--- a/ui/src/components/LeftSidebar.vue
+++ b/ui/src/components/LeftSidebar.vue
@@ -100,23 +100,9 @@ export default {
     return {
       search: "",
       taggedRoutes: [],
+      selectedReport: this.get("selectedReport") || 'queue',
+      loggedUsername: this.get("loggedUser") ? this.get("loggedUser").username : "",
     }
-  },
-  computed: {
-    selectedReport: function () {
-      if (this.get("selectedReport")) {
-        return this.get("selectedReport");
-      } else {
-        return "queue";
-      }
-    },
-    loggedUsername: function () {
-      if (this.get("loggedUser")) {
-        return this.get("loggedUser").username;
-      } else {
-        return "";
-      }
-    },
   },
   watch: {
     search: function (val) {

--- a/ui/src/components/LeftSidebar.vue
+++ b/ui/src/components/LeftSidebar.vue
@@ -100,9 +100,23 @@ export default {
     return {
       search: "",
       taggedRoutes: [],
-      selectedReport: this.get("selectedReport") || 'queue',
-      loggedUsername: this.get("loggedUser").username
     }
+  },
+  computed: {
+    selectedReport: function () {
+      if (this.get("selectedReport")) {
+        return this.get("selectedReport");
+      } else {
+        return "queue";
+      }
+    },
+    loggedUsername: function () {
+      if (this.get("loggedUser")) {
+        return this.get("loggedUser").username;
+      } else {
+        return "";
+      }
+    },
   },
   watch: {
     search: function (val) {

--- a/ui/src/components/LineChart.vue
+++ b/ui/src/components/LineChart.vue
@@ -15,6 +15,12 @@ export default {
     data: {
       type: Array,
     },
+    officeHours: {
+      type: Object,
+    },
+    filterTimeSplit: {
+      type: Number,
+    },
     styles: {
       type: Object,
       default: function () {

--- a/ui/src/components/TableChart.vue
+++ b/ui/src/components/TableChart.vue
@@ -778,6 +778,10 @@ export default {
         hoursMapSorted[hour] = Array.from(hourSet).sort();
       }
 
+      console.log("pivotMap", pivotMap); ////
+      console.log("totalsMap", totalsMap); ////
+      console.log("hoursMapSorted", hoursMapSorted); ////
+
       // process column headers
 
       let processedColumns = [];

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -265,15 +265,10 @@ var UtilService = {
 
       return topDatasetsRows.concat(othersRows);
     },
-    // getMomentTime(timeString) { ////
-    //   // returns a moment object that represents today at the time specified by input timeString
-    //   let momentTime = moment().zone('GMT');
-    //   let hhmm = timeString.split(/:/);
-    //   momentTime.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
-    //   return momentTime;
-    // },
     getMomentStartOfHour(timeString) {
       // returns a moment object that represents today at the start of hour specified by timeString
+      // e.g. timestring: 09:35 -> 09:00
+      // e.g. timestring: 10:00 -> 10:00
       let momentTime = moment().zone('GMT');
 
       // timeString is expressed in HH:mm format
@@ -281,36 +276,29 @@ var UtilService = {
       momentTime.hours(parseInt(hhmm[0])).startOf('hour');
       return momentTime;
     },
-    getMomentEndOfHour(timeString) {
-      // returns a moment object that represents today at the end of hour specified by timeString
+    getMomentNextHour(timeString) {
+      // returns a moment object that represents today at the next hour specified by timeString
+      // e.g. timestring: 09:25 -> 10:00
+      // e.g. timestring: 10:00 -> 10:00
       let momentTime = moment().zone('GMT');
 
       // timeString is expressed in HH:mm format
       let hhmm = timeString.split(/:/);
-      momentTime.hours(parseInt(hhmm[0])).endOf('hour');
-      return momentTime;
+
+      momentTime.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
+
+      if (momentTime.minutes() == 0) {
+        return momentTime;
+      } else {
+        return momentTime.startOf('hour').add(1, 'hour');
+      }
     },
     generateTimeLabelsLineOrBarChart(officeHours, timeSplit, that) {
       let labelSet = new Set();
       const officeHoursStartString = officeHours.startHour;
       const officeHoursEndString = officeHours.endHour;
-
-      // office hour start
-
-      // let officeHoursStart = moment().zone('GMT'); ////
-      // let hhmm = officeHoursStartString.split(/:/);
-      // officeHoursStart.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
-      
-
-      // office hour end
-
-      // let officeHoursEnd = moment().zone('GMT'); ////
-      // hhmm = officeHoursEndString.split(/:/);
-      // officeHoursEnd.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
-
       let hourStart = that.getMomentStartOfHour(officeHoursStartString);
-      let hourEnd = that.getMomentEndOfHour(officeHoursEndString);
-
+      let hourEnd = that.getMomentNextHour(officeHoursEndString);
       let currentTime = hourStart;
 
       while (currentTime.isBefore(hourEnd)) {
@@ -320,15 +308,33 @@ var UtilService = {
       labelSet.add(currentTime.format("HH:mm"));
       return labelSet;
     },
-    // generateHoursMap(officeHours, timeSplit, that) {
-    //   const officeHoursStartString = officeHours.startHour;
-    //   const officeHoursEndString = officeHours.endHour;
+    generateHoursMap(officeHours, timeSplit, that) {
+      const officeHoursStartString = officeHours.startHour;
+      const officeHoursEndString = officeHours.endHour;
 
-    //   let officeHoursStart = that.getMomentTime(officeHoursStartString);
-    //   let officeHoursEnd = that.getMomentTime(officeHoursEndString);
-      
+      let hourStart = that.getMomentStartOfHour(officeHoursStartString);
+      let hourEnd = that.getMomentNextHour(officeHoursEndString);
 
-    // }
+      let currentHourString = hourStart.format("HH:mm");
+      let hoursMap = {};
+      hoursMap[currentHourString] = [currentHourString];
+      let currentTime = hourStart.add(timeSplit, "minutes");
+
+      while (currentTime.isBefore(hourEnd)) {
+        let currentTimeString = currentTime.format("HH:mm");
+
+        if (currentTime.minutes() == 0) {
+          hoursMap[currentTimeString] = [currentTimeString];
+          currentHourString = currentTimeString;
+        } else {
+          hoursMap[currentHourString].push(currentTimeString);
+        }
+        currentTime.add(timeSplit, "minutes");
+      }
+      let currentTimeString = currentTime.format("HH:mm");
+      hoursMap[currentTimeString] = [currentTimeString];
+      return hoursMap;
+    }
   }
 };
 export default UtilService;

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -128,7 +128,7 @@ var UtilService = {
       // if labels match HH:mm, generate all labels using office hours and time split
       if (/^[0-2][0-9]:[0-5][0-9]$/.test(rows[0][1])) {
         officeHoursLabels = true;
-        labelSet = that.generateTimeLabelsLineOrBarChart(that);
+        labelSet = that.generateTimeLabelsLineOrBarChart(that.officeHours, that.filterTimeSplit, that);
       }
 
       rows.forEach((row) => {
@@ -276,30 +276,70 @@ var UtilService = {
 
       return topDatasetsRows.concat(othersRows);
     },
-    generateTimeLabelsLineOrBarChart(that) {
+    // getMomentTime(timeString) { ////
+    //   // returns a moment object that represents today at the time specified by input timeString
+    //   let momentTime = moment().zone('GMT');
+    //   let hhmm = timeString.split(/:/);
+    //   momentTime.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
+    //   return momentTime;
+    // },
+    getMomentStartOfHour(timeString) {
+      // returns a moment object that represents today at the start of hour specified by timeString
+      let momentTime = moment().zone('GMT');
+
+      // timeString is expressed in HH:mm format
+      let hhmm = timeString.split(/:/);
+      momentTime.hours(parseInt(hhmm[0])).startOf('hour');
+      return momentTime;
+    },
+    getMomentEndOfHour(timeString) {
+      // returns a moment object that represents today at the end of hour specified by timeString
+      let momentTime = moment().zone('GMT');
+
+      // timeString is expressed in HH:mm format
+      let hhmm = timeString.split(/:/);
+      momentTime.hours(parseInt(hhmm[0])).endOf('hour');
+      return momentTime;
+    },
+    generateTimeLabelsLineOrBarChart(officeHours, timeSplit, that) {
       let labelSet = new Set();
-      const officeHoursStartString = that.officeHours.startHour;
-      const officeHoursEndString = that.officeHours.endHour;
+      const officeHoursStartString = officeHours.startHour;
+      const officeHoursEndString = officeHours.endHour;
 
       // office hour start
-      let officeHoursStart = moment().zone('GMT');
-      let hhmm = officeHoursStartString.split(/:/);
-      officeHoursStart.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
+
+      // let officeHoursStart = moment().zone('GMT'); ////
+      // let hhmm = officeHoursStartString.split(/:/);
+      // officeHoursStart.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
+      
 
       // office hour end
-      let officeHoursEnd = moment().zone('GMT');
-      hhmm = officeHoursEndString.split(/:/);
-      officeHoursEnd.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
 
-      let currentTime = officeHoursStart;
+      // let officeHoursEnd = moment().zone('GMT'); ////
+      // hhmm = officeHoursEndString.split(/:/);
+      // officeHoursEnd.hours(parseInt(hhmm[0])).minutes(parseInt(hhmm[1])).seconds(0).milliseconds(0);
 
-      while (currentTime.isBefore(officeHoursEnd)) {
+      let hourStart = that.getMomentStartOfHour(officeHoursStartString);
+      let hourEnd = that.getMomentEndOfHour(officeHoursEndString);
+
+      let currentTime = hourStart;
+
+      while (currentTime.isBefore(hourEnd)) {
         labelSet.add(currentTime.format("HH:mm"));
-        currentTime.add(that.filterTimeSplit, "minutes");
+        currentTime.add(timeSplit, "minutes");
       }
       labelSet.add(currentTime.format("HH:mm"));
       return labelSet;
-    }
+    },
+    // generateHoursMap(officeHours, timeSplit, that) {
+    //   const officeHoursStartString = officeHours.startHour;
+    //   const officeHoursEndString = officeHours.endHour;
+
+    //   let officeHoursStart = that.getMomentTime(officeHoursStartString);
+    //   let officeHoursEnd = that.getMomentTime(officeHoursEndString);
+      
+
+    // }
   }
 };
 export default UtilService;

--- a/ui/src/services/utils.js
+++ b/ui/src/services/utils.js
@@ -87,17 +87,6 @@ var UtilService = {
           return value;
       }
     },
-    formatDate(date) {
-      let d = new Date(date),
-        month = '' + (d.getMonth() + 1),
-        day = '' + d.getDate(),
-        year = d.getFullYear();
-      if (month.length < 2)
-        month = '0' + month;
-      if (day.length < 2)
-        day = '0' + day;
-      return [year, month, day].join('/');
-    },
     watchDataLineOrBarChart(that) {
       if (!that.data || that.data.length <= 1) {
         // no data

--- a/ui/src/views/QueueView.vue
+++ b/ui/src/views/QueueView.vue
@@ -57,7 +57,7 @@
           <div v-show="chart.data && chart.data.length > 1">
             <!-- table chart -->
             <div v-if="chart.type == 'table'">
-              <TableChart :caption="chart.caption" :data="chart.data" :chartKey="`${index}`"/>
+              <TableChart :caption="chart.caption" :data="chart.data" :chartKey="`${index}`" :officeHours="officeHours" :filterTimeSplit="filterTimeSplit" />
             </div>
             <!-- line chart -->
             <div v-if="chart.type == 'line'">

--- a/ui/src/views/QueueView.vue
+++ b/ui/src/views/QueueView.vue
@@ -142,6 +142,11 @@ export default {
 
     // get office hours
     this.getAdminSettings();
+
+    // if coming back from CDR report, retrieve query tree again
+    if (this.$root.filtersReady && !this.queryTree) {
+        this.retrieveQueryTree();
+    }
   },
   watch: {
     $route: function () {


### PR DESCRIPTION
- Line/bar charts having **HH:mm** values on X axis should display all time intervals defined by office hours and filter time period (e.g. if **office hours: 09:00 -> 18:00** and **filter time period: 30 minutes**, then X axis displays `09:00`, `09:30`, `10:00`, `10:30`, ..., `17:30`, `18:00`)
- The same applies to table charts with **HH:mm** headers
- Fix default value for filter time group and period
- Fix null check on loggedUsername
- Remove unnecessary event emission from `FixedBar`
- Fix format of time interval in active filters
- Fix chart loading after switching to CDR

https://github.com/nethesis/dev/issues/5865