### PR TITLE
Show an error message if chart loading fails

### DIFF
--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -153,7 +153,8 @@
       "search_name_validation": "Search name must begin with a letter and contain only letters, spaces, numbers and dashes",
       "coming_soon": "Coming soon",
       "cdr_not_available": "CDR & Cost report is not available yet, please come back later",
-      "loading_filters": "Loading filters"
+      "loading_filters": "Loading filters",
+      "chart_error": "An error occured while loading chart"
     },
     "pagination": {
       "page": "page",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -153,7 +153,8 @@
       "search_name_validation": "Il nome della ricerca deve iniziare con una lettera e contenere solamente lettere, spazi, numeri e trattini",
       "coming_soon": "Coming soon",
       "cdr_not_available": "Il report CDR & Cost non è ancora disponibile, torna più tardi",
-      "loading_filters": "Caricamento filtri"
+      "loading_filters": "Caricamento filtri",
+      "chart_error": "Si è verificato un errore durante il caricamento del grafico"
     },
     "pagination": {
       "page": "pagina",

--- a/ui/src/views/QueueView.vue
+++ b/ui/src/views/QueueView.vue
@@ -35,12 +35,17 @@
           />
         </div>
         <div v-show="!chart.data">
-            <sui-loader v-if="!chart.message" active centered inline class="loader-height" />
-            <div v-else>
+            <div v-if="chart.error">
+              <sui-message error>
+                <i class="circle times icon"></i>{{ $t("message.chart_error") }}
+              </sui-message>
+            </div>
+            <div v-else-if="chart.message">
               <sui-message warning>
                 <i class="exclamation triangle icon"></i>{{ $t("message." + chart.message) }}
               </sui-message>
             </div>
+            <sui-loader v-else active centered inline class="loader-height" />
         </div>
         <div v-show="chart.data">
           <div v-show="chart.data && chart.data.length < 2">
@@ -189,6 +194,7 @@ export default {
               data: null,
               message: null,
               details: null,
+              error: false,
             });
           });
           this.charts = charts.sort(this.sortByProperty("position"));
@@ -203,6 +209,7 @@ export default {
         chart.data = null;
         chart.message = null;
         chart.details = null;
+        chart.error = false;
 
         this.execQuery(
           filter,
@@ -231,6 +238,7 @@ export default {
           },
           (error) => {
             console.error(error.body);
+            chart.error = true;
           }
         );
       }


### PR DESCRIPTION
Display an error message instead of loader whenever a chart processing fails (i.e. its query fails for some reason)

https://github.com/nethesis/dev/issues/5865