### PR TITLE
Highlight cost settings on costs configuration & minor UI changes

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -260,7 +260,7 @@ body {
 }
 
 .modals {
-  z-index: 100 !important;
+  z-index: 1001 !important;
 }
 
 .icon.cursor-default {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -400,4 +400,18 @@ body {
   border-color: #e0b4b4 !important;
   color: #9f3a38 !important;
 }
+
+.blink-icon {
+  font-size: 1.1rem !important;
+}
+
+.blink-opacity {
+  animation: blinkOpacity 2s infinite;
+}
+
+@keyframes blinkOpacity{
+  0%		{ opacity: 1;}
+  50%		{ opacity: 0.25;}
+  100%	{ opacity: 1;}
+}
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -189,6 +189,10 @@ body {
   margin-left: 0 !important;
 }
 
+.mg-left-sm {
+  margin-left: 1rem !important;
+}
+
 .mg-top-md {
   margin-top: 2rem !important;
   padding-left: 7px;

--- a/ui/src/components/LeftSidebar.vue
+++ b/ui/src/components/LeftSidebar.vue
@@ -23,6 +23,11 @@
           </sui-dropdown-item>
         </sui-dropdown-menu>
       </sui-dropdown>
+      <span>
+        <sui-popup :content="$t('message.access_cdr_report')" flowing>
+          <sui-icon v-show="$route.meta.report != 'cdr' && !cdrVisited" name="exclamation circle" color="blue" class="blink-opacity blink-icon mg-left-sm" slot="trigger"/>
+        </sui-popup>
+      </span>
     </div>
   </sui-menu-item>
   <sui-menu-item>
@@ -106,6 +111,7 @@ export default {
       taggedRoutes: [],
       selectedReport: this.get("selectedReport") || 'queue',
       loggedUsername: this.get("loggedUser") ? this.get("loggedUser").username : "",
+      cdrVisited: false,
     }
   },
   watch: {
@@ -125,7 +131,14 @@ export default {
       } else {
         this.taggedRoutes = []
       }
-    }
+    },
+    $route: function () {
+      this.checkCdrVisited();
+    },
+  },
+  mounted() {
+    this.cdrVisited = this.get("cdrVisited");
+    this.checkCdrVisited();
   },
   methods: {
     selectReport(report) {
@@ -143,7 +156,13 @@ export default {
     },
     handlePropagation(event) {
       event.stopPropagation()
-    }
+    },
+    checkCdrVisited() {
+      if (!this.cdrVisited && this.$route.meta.report == "cdr") {
+        this.cdrVisited = true;
+        this.set("cdrVisited", true);
+      }
+    },
   }
 };
 </script>
@@ -175,8 +194,6 @@ export default {
     width: 100%;
 
     .dropdown {
-      width: 100%;
-
       .text {
         font-size: 17px;
         font-weight: 600;

--- a/ui/src/components/RecapChart.vue
+++ b/ui/src/components/RecapChart.vue
@@ -195,7 +195,7 @@
                     type="button"
                     @click="entry.expanded = false"
                     size="tiny"
-                    icon="zoom"
+                    icon="zoom-out"
                     >{{ $t("command.collapse") }}</sui-button
                   >
                 </sui-statistic>

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -136,7 +136,14 @@
               $t("message.currency_description")
             }}</div>
             <!-- destinations -->
-            <sui-header>{{ $t('settings.destinations') }}</sui-header>
+            <sui-header>
+              {{ $t('settings.destinations') }}
+              <span>
+                <sui-popup :content="$t('message.configure_to_compute_call_costs')">
+                  <sui-icon v-show="highlightCostsSettings" name="exclamation circle" color="blue" class="blink-opacity blink-icon" slot="trigger"/>
+                </sui-popup>
+              </span>
+            </sui-header>
             <div class="settings-description">{{
               $t("message.destinations_description")
             }}</div>
@@ -170,7 +177,14 @@
             <sui-accordion exclusive class="call-patterns-accordion">
               <sui-accordion-title>
                 <sui-icon name="dropdown" />
-                <a>{{ $t('settings.call_patterns_accordion') }}</a>
+                <a>
+                  {{ $t('settings.call_patterns_accordion') }}
+                  <span>
+                  <sui-popup :content="$t('message.configure_to_compute_call_costs')">
+                    <sui-icon v-show="highlightCostsSettings" name="exclamation circle" color="blue" class="blink-opacity blink-icon" slot="trigger"/>
+                  </sui-popup>
+                </span>
+                </a>
               </sui-accordion-title>
               <sui-accordion-content>
                 <div class="settings-description no-mg-top">{{
@@ -236,7 +250,14 @@
               </sui-accordion-content>
             </sui-accordion>
             <!-- costs -->
-            <sui-header>{{ $t('settings.costs') }}</sui-header>
+            <sui-header>
+              {{ $t('settings.costs') }}
+              <span>
+                <sui-popup :content="$t('message.configure_to_compute_call_costs')">
+                  <sui-icon v-show="highlightCostsSettings" name="exclamation circle" color="blue" class="blink-opacity blink-icon" slot="trigger"/>
+                </sui-popup>
+              </span>
+            </sui-header>
             <div class="settings-description">{{
               $t("message.costs_description")
             }}</div>
@@ -512,6 +533,7 @@ export default {
         cost: "",
       },
       openDeleteCostModal: false,
+      highlightCostsSettings: false,
       colorSchemes: [
         "tableau.Classic10",
         "brewer.DarkTwo8",
@@ -735,6 +757,10 @@ export default {
     },
     showSettingsModal(value) {
       this.openSettingsModal = value;
+
+      if (!value) {
+        this.highlightCostsSettings = false;
+      }
     },
     validateAdminSettings() {
       // reset errors
@@ -893,6 +919,7 @@ export default {
     configureCosts() {
       this.openCostsConfigModal = false;
       this.showSettingsModal(true);
+      this.highlightCostsSettings = true;
       this.set("costsConfigured", true);
     },
     skipCostsConfiguration() {

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -369,7 +369,7 @@
     <!-- configure costs modal -->
     <sui-form>
       <sui-modal v-model="openCostsConfigModal" size="tiny">
-        <sui-modal-header>{{ $t("message.welcome") }}</sui-modal-header>
+        <sui-modal-header>{{ $t("message.welcome_in_cdr") }}</sui-modal-header>
         <sui-modal-content>
           <sui-modal-description>
             <sui-header>{{ $t('message.configure_call_costs') }}</sui-header>
@@ -696,6 +696,9 @@ export default {
       this.getAdminSettings();
     }
 
+    // event "showCostsConfigModal" is triggered by QueueView
+    this.$root.$on("showCostsConfigModal", this.showCostsConfigModal);
+
     // event "logout" is triggered by $http interceptor if token has expired
     this.$root.$on("logout", this.doLogout);
 
@@ -884,12 +887,6 @@ export default {
 
           // costs
           this.adminSettings.costs = this.mapCostsFromBackend(settings.costs);
-
-          // need to show costs configuration modal?
-          const costsConfigured = this.get("costsConfigured");
-          if (!costsConfigured && (!this.adminSettings.costs || !this.adminSettings.costs.length)) {
-            this.openCostsConfigModal = true;
-          }
 
           this.retrieveTrunks();
         },
@@ -1120,6 +1117,9 @@ export default {
         }
         return costsBackend;
     },
+    showCostsConfigModal() {
+      this.openCostsConfigModal = true;
+    }
   },
 };
 </script>

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -158,7 +158,7 @@
       "query_limit_description": "This is the maximum number of results that can be displayed by a table chart. If this limit is reached a warning icon is shown next to chart title",
       "slow_query": "Processing is taking a while. Please narrow search filters, or keep waiting",
       "cdr_details_wait": "This operation can take a while, please wait or come back later...",
-      "welcome": "Welcome",
+      "welcome_in_cdr": "Welcome in CDR & Cost report",
       "configure_call_costs": "First of all, configure destinations and call costs",
       "configure_call_costs_description": "You can do it anytime in Settings page, by clicking cogs button in top-right toolbar",
       "currency_description": "Currency used to display calls cost",

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -164,7 +164,8 @@
       "currency_description": "Currency used to display calls cost",
       "destinations_description": "Destinations are used to configure destination prefixes and compute calls cost",
       "costs_description": "Configure call costs for specific trunks and destinations",
-      "call_patterns_description": "Destination prefixes are used to configure the destination of phone numbers using their prefix. Destination is matched with most specific (lengthy) prefix"
+      "call_patterns_description": "Destination prefixes are used to configure the destination of phone numbers using their prefix. Destination is matched with most specific (lengthy) prefix",
+      "configure_to_compute_call_costs": "Configure this setting to compute and display call costs"
     },
     "pagination": {
       "page": "page",

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -165,7 +165,8 @@
       "destinations_description": "Destinations are used to configure destination prefixes and compute calls cost",
       "costs_description": "Configure call costs for specific trunks and destinations",
       "call_patterns_description": "Destination prefixes are used to configure the destination of phone numbers using their prefix. Destination is matched with most specific (lengthy) prefix",
-      "configure_to_compute_call_costs": "Configure this setting to compute and display call costs"
+      "configure_to_compute_call_costs": "Configure this setting to compute and display call costs",
+      "access_cdr_report": "Access CDR & Cost report"
     },
     "pagination": {
       "page": "page",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -42,7 +42,7 @@
     },
     "menu": {
       "queue": "Report Code",
-      "cdr": "Report Chiamate & Report Costi",
+      "cdr": "Report Chiamate & Costi",
       "dashboard": "Dashboard",
       "data": "Dati",
       "performance": "Performance",
@@ -165,7 +165,8 @@
       "destinations_description": "Le destinazioni sono usate per raggruppare i prefissi di destinazione delle chiamate e calcolare i costi delle chiamate",
       "costs_description": "Configura il costo delle chiamate per fasci specifici e destinazioni specifiche",
       "call_patterns_description": "I prefissi di destinazione son usati per configurare la destinazione dei numeri di telefono usando il loro prefisso. La destinazione è selezionata in base al prefisso più specifico (lungo)",
-      "configure_to_compute_call_costs": "Configura questa impostazione per calcolare e visualizzare i costi delle chiamate"
+      "configure_to_compute_call_costs": "Configura questa impostazione per calcolare e visualizzare i costi delle chiamate",
+      "access_cdr_report": "Accedi al Report Chiamate & Costi"
     },
     "pagination": {
       "page": "pagina",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -158,7 +158,7 @@
       "query_limit_description": "Questo è il numero massimo di risultati che possono essere mostrati da un grafico tabellare. Se questo limite viene raggiunto appare un'icona di avvertimento di fianco al titolo del grafico",
       "slow_query": "Il caricamento sta impiegando più del previsto. Restringi i filtri di ricerca, oppure continua ad attendere",
       "cdr_details_wait": "Questa operazione potrebbe richiedere un po' di tempo, attendi oppure torna più tardi...",
-      "welcome": "Benvenuto/a",
+      "welcome_in_cdr": "Benvenuto/a nel Report Chiamate & Costi",
       "configure_call_costs": "Per prima cosa, configura le destinazioni e i costi delle chiamate",
       "configure_call_costs_description": "Puoi farlo in qualunque momento nella pagina Impostazioni, cliccando il pulsante con ingranaggio nella barra degli strumenti in alto a destra",
       "currency_description": "Valuta usata per mostrare il costo delle chiamate",

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -164,7 +164,8 @@
       "currency_description": "Valuta usata per mostrare il costo delle chiamate",
       "destinations_description": "Le destinazioni sono usate per raggruppare i prefissi di destinazione delle chiamate e calcolare i costi delle chiamate",
       "costs_description": "Configura il costo delle chiamate per fasci specifici e destinazioni specifiche",
-      "call_patterns_description": "I prefissi di destinazione son usati per configurare la destinazione dei numeri di telefono usando il loro prefisso. La destinazione è selezionata in base al prefisso più specifico (lungo)"
+      "call_patterns_description": "I prefissi di destinazione son usati per configurare la destinazione dei numeri di telefono usando il loro prefisso. La destinazione è selezionata in base al prefisso più specifico (lungo)",
+      "configure_to_compute_call_costs": "Configura questa impostazione per calcolare e visualizzare i costi delle chiamate"
     },
     "pagination": {
       "page": "pagina",


### PR DESCRIPTION
On first configuration, a modal suggests to configure destinations and costs.
Use a subtle blinking icon to highlight costs settings inside admin settings modal

Other changes:
- show first configuration modal only in CDR report
- show blinking icon for first access on CDR report
- fix `z-index` of loaders
- fix icon for **Collapse** button

https://github.com/nethesis/dev/issues/5907