### PR TITLE
Temporary icon for newly created object

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -181,6 +181,10 @@ body {
   width: 100% !important;
 }
 
+.no-mg {
+  margin: 0 !important;
+}
+
 .no-mg-top {
   margin-top: 0 !important;
 }
@@ -417,5 +421,9 @@ body {
   0%		{ opacity: 1;}
   50%		{ opacity: 0.25;}
   100%	{ opacity: 1;}
+}
+
+.created-icon {
+  margin: 0.5rem 0 0 0 !important;
 }
 </style>

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -150,8 +150,13 @@
             <sui-card-group :items-per-row="3">
               <sui-card v-for="(destination, index) in adminSettings.destinations" v-bind:key="'destination-' + index" class="destination">
                 <sui-card-content>
-                  <sui-icon name="map marker alternate" class="right floated" />
+                  <sui-icon name="map marker alternate" class="right floated no-mg" size="large" />
                   <sui-card-header>{{ destination }}</sui-card-header>
+                  <span v-show="destination == destinationJustCreated">
+                    <sui-popup :content="$t('misc.just_created')">
+                      <sui-icon name="check circle" color="green" size="large" class="created-icon" slot="trigger" />
+                    </sui-popup>
+                  </span>
                 </sui-card-content>
                 <sui-button basic negative attached="bottom" type="button" @click="showDeleteDestinationModal(destination)">
                   <sui-icon name="trash" /> {{ $t('command.delete') }}
@@ -160,7 +165,7 @@
               <!-- new destination -->
               <sui-card class="destination">
                 <sui-card-content>
-                  <sui-icon name="map marker alternate" class="right floated" />
+                  <sui-icon name="map marker alternate" class="right floated no-mg" size="large" />
                   <sui-input
                     v-model.trim="newDestination"
                     :placeholder="$t('settings.new_destination')"
@@ -214,6 +219,14 @@
                     <sui-button basic negative type="button" @click="showDeleteCallPatternModal(callPattern)">
                       <sui-icon name="trash" /> {{ $t('command.delete') }}
                     </sui-button>
+                  </sui-form-field>
+                  <sui-form-field>
+                    <label class="color-transparent">.</label>
+                    <span v-show="callPattern.prefix == callPatternJustCreated.prefix">
+                      <sui-popup :content="$t('misc.just_created')">
+                        <sui-icon name="check circle" color="green" size="large" class="created-icon" slot="trigger" />
+                      </sui-popup>
+                    </span>
                   </sui-form-field>
                 </sui-form-fields>
                 <!-- new call pattern -->
@@ -295,11 +308,19 @@
                   disabled
                 >
               </sui-form-field>
-              <sui-form-field width="three">
+              <sui-form-field>
                 <label class="color-transparent">.</label>
                 <sui-button basic negative type="button" @click="showDeleteCostModal(cost)">
                   <sui-icon name="trash" /> {{ $t('command.delete') }}
                 </sui-button>
+              </sui-form-field>
+              <sui-form-field>
+                <label class="color-transparent">.</label>
+                <span v-show="cost.channelId == costJustCreated.channelId && cost.destination == costJustCreated.destination">
+                  <sui-popup :content="$t('misc.just_created')">
+                    <sui-icon name="check circle" color="green" size="large" class="created-icon" slot="trigger" />
+                  </sui-popup>
+                </span>
               </sui-form-field>
             </sui-form-fields>
             <!-- new cost -->
@@ -582,6 +603,16 @@ export default {
       openDeleteCostModal: false,
       highlightCostsSettings: false,
       openResetSettingsModal: false,
+      destinationJustCreated: "",
+      callPatternJustCreated: {
+        prefix: "",
+        destination: null,
+      },
+      costJustCreated: {
+        channelId: null,
+        destination: null,
+        cost: "",
+      },
       colorSchemes: [
         "tableau.Classic10",
         "brewer.DarkTwo8",
@@ -988,6 +1019,13 @@ export default {
         return;
       }
       this.adminSettings.destinations.push(this.newDestination);
+
+      // show temporary icon for destination just created
+      this.destinationJustCreated = this.newDestination;
+      setTimeout(() => {
+        this.destinationJustCreated = "";
+      }, 5000);
+
       this.saveAdminSettings(false);
       this.newDestination = "";
     },
@@ -1021,6 +1059,13 @@ export default {
         return;
       }
       this.adminSettings.callPatterns.push(this.newCallPattern);
+
+      // show temporary icon for call pattern just created
+      this.callPatternJustCreated = this.newCallPattern;
+      setTimeout(() => {
+        this.callPatternJustCreated = { prefix: "", destination: null };
+      }, 5000);
+
       this.saveAdminSettings(false);
       this.newCallPattern = { prefix: "", destination: null };
     },
@@ -1068,6 +1113,13 @@ export default {
         return;
       }
       this.adminSettings.costs.push(this.newCost);
+
+      // show temporary icon for cost just created
+      this.costJustCreated = this.newCost;
+      setTimeout(() => {
+        this.costJustCreated = { channelId: null, destination: null, cost: "" };
+      }, 5000);
+
       this.saveAdminSettings(false);
       this.newCost = { channelId: null, destination: null, cost: "" };
     },
@@ -1251,10 +1303,6 @@ export default {
 
 .destination .header {
   font-size: 1.1em !important;
-}
-
-.destination .icon {
-  margin: 0;
 }
 
 .destination .input {

--- a/ui/src/i18n/locale-en.json
+++ b/ui/src/i18n/locale-en.json
@@ -333,7 +333,8 @@
       "others": "Others",
       "call_details": "Call details",
       "per_second": "per second",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "just_created": "Just created"
     },
     "validation": {
       "invalid_value": "Invalid value"

--- a/ui/src/i18n/locale-it.json
+++ b/ui/src/i18n/locale-it.json
@@ -333,7 +333,8 @@
       "others": "Altri",
       "call_details": "Dettagli chiamata",
       "per_second": "al secondo",
-      "unknown": "Sconosciuto"
+      "unknown": "Sconosciuto",
+      "just_created": "Appena creato"
     },
     "validation": {
       "invalid_value": "Valore non valido"


### PR DESCRIPTION
Show a temporary icon for newly created objects (destinations, destination prefixes, costs) in admin settings.
This is especially useful for destination prefixes, since they are automatically sorted by length and newly created object can go out of sight

https://github.com/nethesis/dev/issues/5907