### PR TITLE
ui. handle cdr data not available

### DIFF
--- a/ui/src/components/Filters.vue
+++ b/ui/src/components/Filters.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <sui-container v-if="this.showFiltersForm">
+    <sui-container v-show="this.showFiltersForm">
       <sui-form class="filters-form" @submit.prevent="applyFilters">
         <!-- saved searches -->
         <sui-form-fields v-if="savedSearches.length" class="mg-bottom-md">

--- a/ui/src/components/FixedBar.vue
+++ b/ui/src/components/FixedBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="dataAvailable" class="fixedbar-container" :style="styleObject">
+  <div v-show="(dataAvailable && $route.meta.report == 'queue') || (cdrDataAvailable && $route.meta.report == 'cdr')" class="fixedbar-container" :style="styleObject">
     <div class="fixedbar" :class="{ fixed: isFixed }">
       <sui-container>
         <strong class="activeFilters">{{$t('menu.active_filters')}}: </strong>
@@ -277,6 +277,7 @@ export default {
       isFixed: false,
       offsetTop: "",
       dataAvailable: true,
+      cdrDataAvailable: true,
       styleObject: {
         "min-height": "62px"
       }
@@ -289,8 +290,11 @@ export default {
       window.addEventListener('scroll', this.scrollHandler, true)
     })
 
-    // event "dataNotAvailable" is triggered by $http interceptor if report tables don't exist yet
+    // event "dataNotAvailable" is triggered by $http interceptor if queue report tables don't exist yet
     this.$root.$on("dataNotAvailable", this.onDataNotAvailable);
+
+    // event "cdrDataNotAvailable" is triggered by $http interceptor if cdr report tables don't exist yet
+    this.$root.$on("cdrDataNotAvailable", this.onCdrDataNotAvailable);
   },
   destroyed() {
     window.removeEventListener('scroll', this.scrollHandler);
@@ -305,6 +309,9 @@ export default {
     },
     onDataNotAvailable() {
       this.dataAvailable = false;
+    },
+    onCdrDataNotAvailable() {
+      this.cdrDataAvailable = false;
     },
     scrollHandler(evt) {
       if (evt.target.attributes["views-wrapper"] && (window.innerWidth > this.$mobileBound)) {

--- a/ui/src/components/TopBar.vue
+++ b/ui/src/components/TopBar.vue
@@ -57,7 +57,7 @@
             v-on:click="toggleFilters()"
             class="filter-button"
             :active="showFilters"
-            :disabled="!dataAvailable"
+            :disabled="!((dataAvailable && $route.meta.report == 'queue') || (cdrDataAvailable && $route.meta.report == 'cdr'))"
             :content="$t('menu.filters')"
             icon="filter"
           />
@@ -791,6 +791,7 @@ export default {
       openCostsConfigModal: false,
       isAdmin: false,
       dataAvailable: true,
+      cdrDataAvailable: true,
       newDestination: "",
       openDeleteDestinationModal: false,
       destinationToDelete: "",
@@ -999,8 +1000,11 @@ export default {
     // event "logout" is triggered by $http interceptor if token has expired
     this.$root.$on("logout", this.doLogout);
 
-    // event "dataNotAvailable" is triggered by $http interceptor if report tables don't exist yet
+    // event "dataNotAvailable" is triggered by $http interceptor if queue report tables don't exist yet
     this.$root.$on("dataNotAvailable", this.onDataNotAvailable);
+
+    // event "cdrDataNotAvailable" is triggered by $http interceptor if cdr report tables don't exist yet
+    this.$root.$on("cdrDataNotAvailable", this.onCdrDataNotAvailable);
 
     this.viewDoc = this.retrieveViewDoc();
     this.retrieveColorScheme();
@@ -1016,6 +1020,10 @@ export default {
             : "") + this.$i18n.t(this.$route.meta.name);
       }
       this.viewDoc = this.retrieveViewDoc();
+
+      if (!((this.dataAvailable && this.$route.meta.report == 'queue') || (this.cdrDataAvailable && this.$route.meta.report == 'cdr'))) {
+        this.showFilters = false;
+      }
     },
   },
   computed: {
@@ -1029,6 +1037,10 @@ export default {
       this.showFilters = false;
       this.dataAvailable = false;
     },
+    onCdrDataNotAvailable() {
+      this.showFilters = false;
+      this.cdrDataAvailable = false;
+    },
     retrieveShowFilter() {
       const showFilters = this.get("showFilters");
 
@@ -1040,7 +1052,7 @@ export default {
       this.$forceUpdate();
     },
     toggleFilters: function () {
-      if (this.dataAvailable) {
+      if ((this.dataAvailable && this.$route.meta.report == 'queue') || (this.cdrDataAvailable && this.$route.meta.report == 'cdr')) {
         this.showFilters = !this.showFilters;
         this.set("showFilters", this.showFilters);
         this.$root.$emit("toggleFilters");

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -35,6 +35,9 @@ Vue.http.interceptors.push(function () {
     if (response.status == 401 && response.body && response.body.message == "Token is expired") {
       // authentication token has expired, show login page
       this.$root.$emit("logout");
+    } else if (response.status == 400 && response.body && /Table 'asteriskcdrdb.+doesn't exist/.test(response.body.status)) {
+      // non-existent table, come back tomorrow
+      this.$root.$emit("cdrDataNotAvailable");
     }
   };
 });

--- a/ui/src/views/ContentView.vue
+++ b/ui/src/views/ContentView.vue
@@ -1,6 +1,6 @@
 <template lang="html">
 <div>
-  <div v-show="!dataAvailable" class="ui placeholder segment report-data-not-available">
+  <div v-show="!((dataAvailable && $route.meta.report == 'queue') || (cdrDataAvailable && $route.meta.report == 'cdr'))" class="ui placeholder segment report-data-not-available">
     <div class="ui icon header">
       <i class="frown outline icon mg-bottom-sm"></i>
       {{ $t("message.come_back_tomorrow") }}
@@ -9,7 +9,7 @@
       {{ $t("message.come_back_tomorrow_desc") }}
     </div>
   </div>
-  <div v-show="dataAvailable">
+  <div v-show="(dataAvailable && $route.meta.report == 'queue') || (cdrDataAvailable && $route.meta.report == 'cdr')">
     <div v-if="!$root.filtersReady">
       <sui-loader active centered inline class="loading-filters" />
       <div>{{ $t("message.loading_filters") }}...</div>
@@ -231,6 +231,7 @@ export default {
       openDetailsModal: false,
       chartDetails: null,
       dataAvailable: true,
+      cdrDataAvailable: true,
       adminSettings: {
         officeHours: {
           start_hour: null,
@@ -260,10 +261,15 @@ export default {
     };
   },
   mounted() {
-    // event "dataNotAvailable" is triggered by $http interceptor if report tables don't exist yet
+    // event "dataNotAvailable" is triggered by $http interceptor if queue report tables don't exist yet
     this.$root.$on("dataNotAvailable", this.onDataNotAvailable);
+
+    // event "cdrDataNotAvailable" is triggered by $http interceptor if cdr report tables don't exist yet
+    this.$root.$on("cdrDataNotAvailable", this.onCdrDataNotAvailable);
+
     // event "reloadAdminSettings" is triggered by TopBar when configuring costs
     this.$root.$on("reloadAdminSettings", this.getAdminSettings);
+
     this.$root.$on("applyFilters", this.applyFilters);
 
     // get office hours
@@ -317,6 +323,9 @@ export default {
     onDataNotAvailable() {
       this.dataAvailable = false;
     },
+    onCdrDataNotAvailable() {
+      this.cdrDataAvailable = false;
+    },
     retrieveQueryTree() {
       this.getQueryTree(
         this.$route.meta.report,
@@ -342,7 +351,7 @@ export default {
       );
     },
     initCharts() {
-      if (this.dataAvailable) {
+      if ((this.dataAvailable && this.$route.meta.report == 'queue') || (this.cdrDataAvailable && this.$route.meta.report == 'cdr')) {
         let charts = [];
 
         this.queries = this.queryTree[this.$route.meta.section][


### PR DESCRIPTION
In some cases (e.g. users of beta version who have just installed CDR report) queue report data is available, but CDR report data is not.
If CDR report data is not available yet, CDR report should inform the user to wait until tomorrow, and queue report should work as expected.

nethesis/dev#5907