### PR TITLE
queries & views. replace src column with cnum

### DIFF
--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/inbound/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/inbound/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "IN"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/inbound/1_table_pbxInbound.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/inbound/1_table_pbxInbound.sql
@@ -1,7 +1,7 @@
 SELECT
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -13,9 +13,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "IN"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/local/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/local/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "LOCAL"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/local/1_table_pbxLocal.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/local/1_table_pbxLocal.sql
@@ -1,7 +1,7 @@
 SELECT
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -12,9 +12,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "LOCAL"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/outbound/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/outbound/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "OUT"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/pbx/outbound/1_table_pbxOutbound.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/pbx/outbound/1_table_pbxOutbound.sql
@@ -1,7 +1,7 @@
 SELECT
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -13,9 +13,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "OUT"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/inbound/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/inbound/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "IN"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/inbound/1_table_personalInbound.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/inbound/1_table_personalInbound.sql
@@ -1,7 +1,7 @@
 SELECT	
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -13,9 +13,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "IN"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/local/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/local/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "LOCAL"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-	  AND (src IN ({{ ExtractStrings .Sources }}) OR dst IN ({{ ExtractStrings .Destinations }}))
+	  AND (cnum IN ({{ ExtractStrings .Sources }}) OR dst IN ({{ ExtractStrings .Destinations }}))
 	{{ else if gt (len .Sources) 0 }}
-	  AND src IN ({{ ExtractStrings .Sources }})
+	  AND cnum IN ({{ ExtractStrings .Sources }})
 	{{ else if gt (len .Destinations) 0 }}
 	  AND dst IN ({{ ExtractStrings .Destinations }})
 	{{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/local/1_table_personalLocal.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/local/1_table_personalLocal.sql
@@ -1,7 +1,7 @@
 SELECT	
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -12,9 +12,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "LOCAL"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-	  AND (src IN ({{ ExtractStrings .Sources }}) OR dst IN ({{ ExtractStrings .Destinations }}))
+	  AND (cnum IN ({{ ExtractStrings .Sources }}) OR dst IN ({{ ExtractStrings .Destinations }}))
 	{{ else if gt (len .Sources) 0 }}
-	  AND src IN ({{ ExtractStrings .Sources }})
+	  AND cnum IN ({{ ExtractStrings .Sources }})
 	{{ else if gt (len .Destinations) 0 }}
 	  AND dst IN ({{ ExtractStrings .Destinations }})
 	{{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/outbound/0_recap_summary.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/outbound/0_recap_summary.sql
@@ -17,9 +17,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "OUT"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/queries/cdr/personal/outbound/1_table_personalOutbound.sql
+++ b/root/opt/nethvoice-report/api/queries/cdr/personal/outbound/1_table_personalOutbound.sql
@@ -1,7 +1,7 @@
 SELECT	
     linkedid,
     DATE_FORMAT(calldate, '%Y-%m-%d %H:%i:%s') AS time£hourDate,
-    src AS src£phoneNumber,
+    cnum AS src£phoneNumber,
     dst AS dst£phoneNumber,
     type AS call_type£label,
     SUBSTRING_INDEX(dispositions, ',',- 1) AS result£label, -- get last disposition
@@ -13,9 +13,9 @@ WHERE	calldate >= "{{ .Time.Interval.Start }}"
 	AND calldate <= "{{ .Time.Interval.End }}"
 	AND type = "OUT"
 	{{ if (and (gt (len .Sources) 0) (gt (len .Destinations) 0)) }}
-          AND (src IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
+          AND (cnum IN ({{ ExtractStrings .Sources }}) AND dst IN ({{ ExtractStrings .Destinations }}))
         {{ else if gt (len .Sources) 0 }}
-          AND src IN ({{ ExtractStrings .Sources }})
+          AND cnum IN ({{ ExtractStrings .Sources }})
         {{ else if gt (len .Destinations) 0 }}
           AND dst IN ({{ ExtractStrings .Destinations }})
         {{ else }}

--- a/root/opt/nethvoice-report/api/views/dashboard_cdr_10_outboundCostByGroup.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_cdr_10_outboundCostByGroup.sql
@@ -22,7 +22,7 @@ SELECT cti_group, Sum(cost) AS cost FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -38,7 +38,7 @@ SELECT cti_group, Sum(cost) AS cost FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -60,7 +60,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -76,7 +76,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -98,7 +98,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -114,7 +114,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -136,7 +136,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -152,7 +152,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -174,7 +174,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -190,7 +190,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -212,7 +212,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -228,7 +228,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -250,7 +250,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -266,7 +266,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -288,7 +288,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -304,7 +304,7 @@ SELECT cti_group, Sum(cost) AS cost  FROM
               Sum(cost) AS cost 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 

--- a/root/opt/nethvoice-report/api/views/dashboard_cdr_11_topCostUsers.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_cdr_11_topCostUsers.sql
@@ -22,7 +22,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -35,7 +35,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -54,7 +54,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -67,7 +67,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -86,7 +86,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -99,7 +99,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -118,7 +118,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -131,7 +131,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -150,7 +150,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -163,7 +163,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -182,7 +182,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -195,7 +195,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -214,7 +214,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -227,7 +227,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -246,7 +246,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 
@@ -259,7 +259,7 @@ SELECT username, Sum(cost) as cost FROM
               Sum(cost) as cost
        FROM   ',@to,' c
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
        WHERE  c.type = "OUT" 

--- a/root/opt/nethvoice-report/api/views/dashboard_cdr_6_inboundRegions.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_cdr_6_inboundRegions.sql
@@ -19,7 +19,7 @@ SET @q_past_year = CONCAT('
 CREATE TABLE dashboard_cdr_6_past_year AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -28,9 +28,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()-INTERVAL 1 YEAR),1)) 
               AND calldate <= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 YEAR, "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -39,7 +39,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()-INTERVAL 1 YEAR),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 YEAR, "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -48,7 +48,7 @@ SET @q_current_year = CONCAT('
 CREATE TABLE dashboard_cdr_6_current_year AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -57,9 +57,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW(), "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -68,7 +68,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW(), "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -77,7 +77,7 @@ SET @q_past_semester = CONCAT('
 CREATE TABLE dashboard_cdr_6_past_semester AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -86,9 +86,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-07-01"), DATE_FORMAT(NOW(), "%Y-01-01")))
               AND calldate <= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-12-31"), DATE_FORMAT(NOW(), "%Y-06-30")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -97,7 +97,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-07-01"), DATE_FORMAT(NOW(), "%Y-01-01")))
               AND calldate <= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-12-31"), DATE_FORMAT(NOW(), "%Y-06-30")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -106,7 +106,7 @@ SET @q_past_quarter = CONCAT('
 CREATE TABLE dashboard_cdr_6_past_quarter AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -115,9 +115,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 2) QUARTER, date_format(NOW() - INTERVAL 1 YEAR, "%Y-10-01")))
               AND calldate <= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 1) QUARTER - INTERVAL 1 DAY, date_format(NOW() - INTERVAL 1 YEAR, "%Y-12-31")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -126,7 +126,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 2) QUARTER, date_format(NOW() - INTERVAL 1 YEAR, "%Y-10-01")))
               AND calldate <= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 1) QUARTER - INTERVAL 1 DAY, date_format(NOW() - INTERVAL 1 YEAR, "%Y-12-31")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -135,7 +135,7 @@ SET @q_past_month = CONCAT('
 CREATE TABLE dashboard_cdr_6_past_month AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -144,9 +144,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 MONTH, "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()-INTERVAL 1 MONTH))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -155,7 +155,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 MONTH, "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()-INTERVAL 1 MONTH))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -164,7 +164,7 @@ SET @q_current_month = CONCAT('
 CREATE TABLE dashboard_cdr_6_current_month AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -173,9 +173,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW(), "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -184,7 +184,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW(), "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -193,7 +193,7 @@ SET @q_past_week = CONCAT('
 CREATE TABLE dashboard_cdr_6_past_week AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -202,9 +202,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -213,7 +213,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 
@@ -222,7 +222,7 @@ SET @q_current_week = CONCAT('
 CREATE TABLE dashboard_cdr_6_current_week AS
 SELECT region, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -231,9 +231,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT regione 
               FROM   zone 
@@ -242,7 +242,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  region IS NOT NULL 
 GROUP  BY region 

--- a/root/opt/nethvoice-report/api/views/dashboard_cdr_7_inboundProvinces.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_cdr_7_inboundProvinces.sql
@@ -19,7 +19,7 @@ SET @q_past_year = CONCAT('
 CREATE TABLE dashboard_cdr_7_past_year AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -28,9 +28,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()-INTERVAL 1 YEAR),1)) 
               AND calldate <= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 YEAR, "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -39,7 +39,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()-INTERVAL 1 YEAR),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 YEAR, "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -48,7 +48,7 @@ SET @q_current_year = CONCAT('
 CREATE TABLE dashboard_cdr_7_current_year AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -57,9 +57,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW(), "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -68,7 +68,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT MAKEDATE(YEAR(NOW()),1))
               AND calldate <= (SELECT DATE_FORMAT(NOW(), "%Y-12-31"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -77,7 +77,7 @@ SET @q_past_semester = CONCAT('
 CREATE TABLE dashboard_cdr_7_past_semester AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -86,9 +86,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-07-01"), DATE_FORMAT(NOW(), "%Y-01-01")))
               AND calldate <= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-12-31"), DATE_FORMAT(NOW(), "%Y-06-30")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -97,7 +97,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-07-01"), DATE_FORMAT(NOW(), "%Y-01-01")))
               AND calldate <= (SELECT IF(MONTH(NOW()) < 7, DATE_FORMAT(NOW() - INTERVAL 1 YEAR, "%Y-12-31"), DATE_FORMAT(NOW(), "%Y-06-30")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -106,7 +106,7 @@ SET @q_past_quarter = CONCAT('
 CREATE TABLE dashboard_cdr_7_past_quarter AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -115,9 +115,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 2) QUARTER, date_format(NOW() - INTERVAL 1 YEAR, "%Y-10-01")))
               AND calldate <= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 1) QUARTER - INTERVAL 1 DAY, date_format(NOW() - INTERVAL 1 YEAR, "%Y-12-31")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -126,7 +126,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 2) QUARTER, date_format(NOW() - INTERVAL 1 YEAR, "%Y-10-01")))
               AND calldate <= (select if(quarter(NOW()) > 1, date_format(NOW(), "%Y-01-01") + INTERVAL (quarter(NOW()) - 1) QUARTER - INTERVAL 1 DAY, date_format(NOW() - INTERVAL 1 YEAR, "%Y-12-31")))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -135,7 +135,7 @@ SET @q_past_month = CONCAT('
 CREATE TABLE dashboard_cdr_7_past_month AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -144,9 +144,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 MONTH, "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()-INTERVAL 1 MONTH))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -155,7 +155,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW()-INTERVAL 1 MONTH, "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()-INTERVAL 1 MONTH))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -164,7 +164,7 @@ SET @q_current_month = CONCAT('
 CREATE TABLE dashboard_cdr_7_current_month AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -173,9 +173,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW(), "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -184,7 +184,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(NOW(), "%Y-%m-01"))
               AND calldate <= (SELECT LAST_DAY(NOW()))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -193,7 +193,7 @@ SET @q_past_week = CONCAT('
 CREATE TABLE dashboard_cdr_7_past_week AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -202,9 +202,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -213,7 +213,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW()-INTERVAL 1 WEEK, INTERVAL(-WEEKDAY(NOW()-INTERVAL 1 WEEK)) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 
@@ -222,7 +222,7 @@ SET @q_current_week = CONCAT('
 CREATE TABLE dashboard_cdr_7_current_week AS
 SELECT province, 
        Sum(total) AS total 
-FROM   (SELECT LEFT(src, 4)               AS prefix, 
+FROM   (SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -231,9 +231,9 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        UNION ALL
-       SELECT LEFT(src, 4)               AS prefix, 
+       SELECT LEFT(cnum, 4)               AS prefix, 
               Count(*)                   AS total, 
               (SELECT provincia 
               FROM   zone 
@@ -242,7 +242,7 @@ FROM   (SELECT LEFT(src, 4)               AS prefix,
        WHERE  type = "IN" 
               AND calldate >= (SELECT DATE_FORMAT(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), "%Y-%m-%d"))
               AND calldate <= (SELECT DATE_FORMAT(DATE_ADD(DATE_ADD(NOW(), INTERVAL(-WEEKDAY(NOW())) DAY), INTERVAL 6 DAY), "%Y-%m-%d"))
-       GROUP  BY LEFT(src, 4)
+       GROUP  BY LEFT(cnum, 4)
        ) t
 WHERE  province IS NOT NULL 
 GROUP  BY province 

--- a/root/opt/nethvoice-report/api/views/dashboard_cdr_9_outboundCallsByGroup.sql
+++ b/root/opt/nethvoice-report/api/views/dashboard_cdr_9_outboundCallsByGroup.sql
@@ -22,7 +22,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -38,7 +38,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -60,7 +60,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -76,7 +76,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -98,7 +98,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -114,7 +114,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -136,7 +136,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -152,7 +152,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -174,7 +174,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -190,7 +190,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -212,7 +212,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -228,7 +228,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -250,7 +250,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -266,7 +266,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -288,7 +288,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@from,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 
@@ -304,7 +304,7 @@ SELECT cti_group, Sum(total) AS total FROM
               Count(*) AS total 
        FROM   ',@to,' c 
               JOIN asterisk.rest_devices_phones p 
-              ON p.extension = c.src
+              ON p.extension = c.cnum
               JOIN asterisk.userman_users u
               ON u.id = p.user_id
               JOIN asterisk.rest_cti_users_groups cg 

--- a/root/opt/nethvoice-report/api/views/data_summary_agent.sql
+++ b/root/opt/nethvoice-report/api/views/data_summary_agent.sql
@@ -9,14 +9,14 @@ DROP TABLE IF EXISTS data_summary_agent_day;
 CREATE TABLE data_summary_agent_year AS
 SELECT
        Date_format(calldate, "%Y") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Count(*) AS total,
        Count(DISTINCT clid) AS uniqCid,
@@ -27,7 +27,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -35,19 +35,19 @@ WHERE
        )
 GROUP BY
        period,
-       src;
+       cnum;
 
 CREATE TABLE data_summary_agent_month AS
 SELECT
        Date_format(calldate, "%Y-%m") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Count(*) AS total,
        Count(DISTINCT clid) AS uniqCid,
@@ -58,7 +58,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -66,19 +66,19 @@ WHERE
        )
 GROUP BY
        period,
-       src;
+       cnum;
 
 CREATE TABLE data_summary_agent_week AS
 SELECT
        Date_format(calldate, "%x-W%v") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Count(*) AS total,
        Count(DISTINCT clid) AS uniqCid,
@@ -89,7 +89,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -97,19 +97,19 @@ WHERE
        )
 GROUP BY
        period,
-       src;
+       cnum;
 
 CREATE TABLE data_summary_agent_day AS
 SELECT
        Date_format(calldate, "%Y-%m-%d") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Count(*) AS total,
        Count(DISTINCT clid) AS uniqCid,
@@ -120,7 +120,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -128,4 +128,4 @@ WHERE
        )
 GROUP BY
        period,
-       src;
+       cnum;

--- a/root/opt/nethvoice-report/api/views/distribution_hour_agent.sql
+++ b/root/opt/nethvoice-report/api/views/distribution_hour_agent.sql
@@ -9,14 +9,14 @@ DROP TABLE IF EXISTS distribution_hour_agent_year_60;
 CREATE TABLE distribution_hour_agent_year_10 AS
 SELECT
        Date_format(calldate, "%Y") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -31,7 +31,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -39,24 +39,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_10
 ORDER BY
        period,
-       src,
+       cnum,
        time_10;
 
 CREATE TABLE distribution_hour_agent_year_15 AS
 SELECT
        Date_format(calldate, "%Y") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -71,7 +71,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -79,24 +79,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_15
 ORDER BY
        period,
-       src,
+       cnum,
        time_15;
 
 CREATE TABLE distribution_hour_agent_year_30 AS
 SELECT
        Date_format(calldate, "%Y") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -111,7 +111,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -119,24 +119,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_30
 ORDER BY
        period,
-       src,
+       cnum,
        time_30;
 
 CREATE TABLE distribution_hour_agent_year_60 AS
 SELECT
        Date_format(calldate, "%Y") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -151,7 +151,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -159,11 +159,11 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_60
 ORDER BY
        period,
-       src,
+       cnum,
        time_60;
 
 DROP TABLE IF EXISTS distribution_hour_agent_month_10;
@@ -177,14 +177,14 @@ DROP TABLE IF EXISTS distribution_hour_agent_month_60;
 CREATE TABLE distribution_hour_agent_month_10 AS
 SELECT
        Date_format(calldate, "%Y-%m") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -199,7 +199,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -207,24 +207,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_10
 ORDER BY
        period,
-       src,
+       cnum,
        time_10;
 
 CREATE TABLE distribution_hour_agent_month_15 AS
 SELECT
        Date_format(calldate, "%Y-%m") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -239,7 +239,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -247,24 +247,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_15
 ORDER BY
        period,
-       src,
+       cnum,
        time_15;
 
 CREATE TABLE distribution_hour_agent_month_30 AS
 SELECT
        Date_format(calldate, "%Y-%m") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -279,7 +279,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -287,24 +287,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_30
 ORDER BY
        period,
-       src,
+       cnum,
        time_30;
 
 CREATE TABLE distribution_hour_agent_month_60 AS
 SELECT
        Date_format(calldate, "%Y-%m") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -319,7 +319,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -327,11 +327,11 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_60
 ORDER BY
        period,
-       src,
+       cnum,
        time_60;
 
 DROP TABLE IF EXISTS distribution_hour_agent_week_10;
@@ -345,14 +345,14 @@ DROP TABLE IF EXISTS distribution_hour_agent_week_60;
 CREATE TABLE distribution_hour_agent_week_10 AS
 SELECT
        Date_format(calldate, "%x-W%v") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -367,7 +367,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -375,24 +375,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_10
 ORDER BY
        period,
-       src,
+       cnum,
        time_10;
 
 CREATE TABLE distribution_hour_agent_week_15 AS
 SELECT
        Date_format(calldate, "%x-W%v") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -407,7 +407,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -415,24 +415,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_15
 ORDER BY
        period,
-       src,
+       cnum,
        time_15;
 
 CREATE TABLE distribution_hour_agent_week_30 AS
 SELECT
        Date_format(calldate, "%x-W%v") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -447,7 +447,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -455,24 +455,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_30
 ORDER BY
        period,
-       src,
+       cnum,
        time_30;
 
 CREATE TABLE distribution_hour_agent_week_60 AS
 SELECT
        Date_format(calldate, "%x-W%v") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -487,7 +487,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -495,11 +495,11 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_60
 ORDER BY
        period,
-       src,
+       cnum,
        time_60;
 
 DROP TABLE IF EXISTS distribution_hour_agent_day_10;
@@ -513,14 +513,14 @@ DROP TABLE IF EXISTS distribution_hour_agent_day_60;
 CREATE TABLE distribution_hour_agent_day_10 AS
 SELECT
        Date_format(calldate, "%Y-%m-%d") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -535,7 +535,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -543,24 +543,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_10
 ORDER BY
        period,
-       src,
+       cnum,
        time_10;
 
 CREATE TABLE distribution_hour_agent_day_15 AS
 SELECT
        Date_format(calldate, "%Y-%m-%d") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -575,7 +575,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -583,24 +583,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_15
 ORDER BY
        period,
-       src,
+       cnum,
        time_15;
 
 CREATE TABLE distribution_hour_agent_day_30 AS
 SELECT
        Date_format(calldate, "%Y-%m-%d") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -615,7 +615,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -623,24 +623,24 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_30
 ORDER BY
        period,
-       src,
+       cnum,
        time_30;
 
 CREATE TABLE distribution_hour_agent_day_60 AS
 SELECT
        Date_format(calldate, "%Y-%m-%d") AS period,
-       src AS agentNum,
+       cnum AS agentNum,
        (
               SELECT
                      name
               FROM
                      agent_extensions
               WHERE
-                     extension = asteriskcdrdb.cdr.src
+                     extension = asteriskcdrdb.cdr.cnum
        ) AS agentName,
        Date_format(
               Sec_to_time(
@@ -655,7 +655,7 @@ FROM
        asteriskcdrdb.cdr
 WHERE
        billsec != 0
-       AND src IN (
+       AND cnum IN (
               SELECT
                      extension
               FROM
@@ -663,9 +663,9 @@ WHERE
        )
 GROUP BY
        period,
-       src,
+       cnum,
        time_60
 ORDER BY
        period,
-       src,
+       cnum,
        time_60;


### PR DESCRIPTION
In some cases `src` column in `asteriskcdrdb.cdr` table does not contain a local sip number.
This is an issue for some charts based on this data.
For this reason `src` column has been replaced with `cnum` column in all materialized views and queries

https://github.com/nethesis/dev/issues/5907