### PR TITLE
tasks. fix cron tasks order

### DIFF
--- a/root/etc/cron.d/nethvoice-report-tasks
+++ b/root/etc/cron.d/nethvoice-report-tasks
@@ -1,11 +1,8 @@
 # Launch miners and tasks at night
-00 00 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php && /opt/nethvoice-report/tasks/tasks views && /opt/nethvoice-report/tasks/tasks queries
+00 00 * * *  asterisk /opt/nethvoice-report/scripts/queue-miner.php && /opt/nethvoice-report/tasks/tasks cdr && /opt/nethvoice-report/tasks/tasks cost && /opt/nethvoice-report/tasks/tasks views && /opt/nethvoice-report/tasks/tasks queries
 
 # precalculate phonebook numbers during night
 10 00 * * *     asterisk /opt/nethvoice-report/tasks/tasks phonebook
 
 # precalculate filter values during night
 20 00 * * *     asterisk /opt/nethvoice-report/tasks/tasks values
-
-# execute cdr task to split cdr table and calculate costs
-30 00 * * *	asterisk /opt/nethvoice-report/tasks/tasks cdr && /opt/nethvoice-report/tasks/tasks cost


### PR DESCRIPTION
Task `cdr` must run before `views`, since the latter acts on tables created by the former.

https://github.com/nethesis/dev/issues/5907