### PR TITLE
api & ui. show only agents of selected queues

### DIFF
--- a/root/opt/nethvoice-report/api/values/queueAgents.sql
+++ b/root/opt/nethvoice-report/api/values/queueAgents.sql
@@ -1,0 +1,12 @@
+SELECT
+    DISTINCT CONCAT(queuename, ",", agent)
+FROM
+    queue_log_history
+WHERE
+    queuename != "NONE"
+    AND queuename != "all"
+    AND agent NOT LIKE 'Local/%@from-queue/n'
+    AND agent NOT LIKE ''
+    AND agent != "NONE"
+ORDER BY
+    queuename, agent;

--- a/tasks/go.mod
+++ b/tasks/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/fatih/color v1.9.0
 	github.com/gin-gonic/gin v1.6.3
-	github.com/nethesis/nethvoice-report/api v0.0.0-20210205110415-9a3776a34cfc
+	github.com/nethesis/nethvoice-report/api v0.0.0-20210419090104-4330b1e5fe02
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1

--- a/tasks/go.sum
+++ b/tasks/go.sum
@@ -199,6 +199,12 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/nethesis/nethvoice-report v0.0.0-20210205110415-9a3776a34cfc h1:ec0Gp9pZjnOFAzSdZ3PueH0RHgEmenFKiYkjcJrJyRk=
 github.com/nethesis/nethvoice-report/api v0.0.0-20210205110415-9a3776a34cfc h1:dJCYqymxBXyqeQwCoXnmQh/k6rs8OF9uMv0Y67lG0TM=
 github.com/nethesis/nethvoice-report/api v0.0.0-20210205110415-9a3776a34cfc/go.mod h1:EVlrgK6wN3zaCi8E0e8A9YwMlTKj+2u8lbFF811x5K8=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210416094223-32cc5c16629e h1:sEE1s1MUiQrrKNTvnUSGvWsKHYZL4vIKfQTJ7AYeDBs=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210416094223-32cc5c16629e/go.mod h1:EVlrgK6wN3zaCi8E0e8A9YwMlTKj+2u8lbFF811x5K8=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210419082642-b0a6400a2c4b h1:bDOsUoAgBYjz0Omde4qYZhGI4ug7xR6ts8HMShZBET8=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210419082642-b0a6400a2c4b/go.mod h1:EVlrgK6wN3zaCi8E0e8A9YwMlTKj+2u8lbFF811x5K8=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210419090104-4330b1e5fe02 h1:0iqb7I3ZMizTTUV2pbisn29Ob3hv3GGinuTAkQMD4A4=
+github.com/nethesis/nethvoice-report/api v0.0.0-20210419090104-4330b1e5fe02/go.mod h1:EVlrgK6wN3zaCi8E0e8A9YwMlTKj+2u8lbFF811x5K8=
 github.com/nleeper/goment v1.4.0 h1:k+PnV26S9wnxI+ryxKEkpG7JhVtDJpM6+CzeRxh5S54=
 github.com/nleeper/goment v1.4.0/go.mod h1:zDl5bAyDhqxwQKAvkSXMRLOdCowrdZz53ofRJc4VhTo=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
- If no queue is selected in **Queues** filter, then **Agents** filter shows options for all agents.
- If the user selects one or more queues in filters, then **Agents** filter shows options for agents belonging to selected queues only
- If the user selects agent **Bob**, then selects a queue that doesn't include Bob, then Bob is removed from selection in **Agents** filter

nethesis/dev#5989