### PR TITLE
Authorization Bypass due to incorrect usage of PAM library

### DIFF
--- a/api/methods/auth.go
+++ b/api/methods/auth.go
@@ -64,6 +64,10 @@ func PamAuth(username string, password string) error {
 	if errAuth != nil {
 		return errAuth
 	}
+	errAuth = t.AcctMgmt(0)
+	if errAuth != nil {
+		return errAuth
+	}
 	return nil
 }
 


### PR DESCRIPTION
Not using `pam_acct_mgmt` after `pam_authenticate` to check the validity of a login can lead to an authorization bypass

## Common Weakness Enumeration(CWE) category
CWE - 863

## Root Cause Analysis

In this case, in the following PAM transaction, only a call to `pam.Authenticate` is used to login a user.

https://lgtm.com/projects/g/nethesis/nethvoice-report/snapshot/4c37ee73a69564895b9db44ec2959766f0fa7bfe/files/api/methods/auth.go#x4b20c1ca54cad81d:1

This implies that a user with expired credentials can still login.

The bug can be verified easily by creating a new user account, expiring it with <code>chage -E0 `username` </code> and then trying to log in with the expired credentials.

## Remediation

This can be fixed by invoking a call to `pam.AcctMgmt` after a successful call to `pam.Authenticate`

## Common Vulnerability Scoring System Vector

### Exploitability

The attack can be carried over the network. A complex non-standard configuration or a specialized condition is required for the attack to be successfully conducted. The attacker also requires access to a users credentials, be it expired, for an attack to be successful. There is no user interaction required for successful execution. The attack can affect components outside the scope of the target module.

### Impact
Using this attack vector, an attacker may access otherwise restricted parts of the system. The attack can be used to gain access to confidential files like passwords, login credentials and other secrets. Hence, it has a high impact on confidentiality. It may also be directly used to affect a change on a system resource. Hence has a medium to high impact on integrity. This attack may not be used to affect the availability of the system. Taking this account an appropriate CVSS v3.1 vector would be

[AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:N](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:L&version=3.1)

This gives it a base score of 7.7/10 and a severity rating of high.

## References
* [Man Page for pam_acct_mgmt](https://man7.org/linux/man-pages/man3/pam_acct_mgmt.3.html)
* [CWE-863](http://cwe.mitre.org/data/definitions/863.html)
* [CWE-285](http://cwe.mitre.org/data/definitions/285.html)
* github/securitylab#561
* github/codeql-go#709

### This bug was found using *[CodeQL by Github](https://codeql.github.com/)*