### PR TITLE
All agents on search bar, avoid authorization 

### DIFF
--- a/api/methods/auth.go
+++ b/api/methods/auth.go
@@ -185,7 +185,7 @@ func ParseAuthMap(c *gin.Context, username string) (models.AuthMap, error) {
 		return models.AuthMap{}, err
 	}
 	// parse authorizations
-	if len(auths.Queues) > 0 && len(auths.Agents) > 0 {
+	if len(auths.Queues) > 0 {
 		authMap.Queues = true
 	}
 	if len(auths.Users) > 0 {

--- a/api/methods/filters.go
+++ b/api/methods/filters.go
@@ -83,6 +83,7 @@ func GetDefaultFilter(c *gin.Context) {
 	auths, _ := GetUserAuthorizations(user)
 
 	// assign default filter intersection
+	defaultFilter.Agents = valuesFilter.Agents
 	defaultFilter.IVRs = valuesFilter.IVRs
 	defaultFilter.Phones = valuesFilter.Phones
 	defaultFilter.Reasons = valuesFilter.Reasons
@@ -98,12 +99,10 @@ func GetDefaultFilter(c *gin.Context) {
 	if user == "X" || user == "admin" {
 		defaultFilter.Queues = valuesFilter.Queues
 		defaultFilter.Groups = valuesFilter.Groups
-		defaultFilter.Agents = valuesFilter.Agents
 		defaultFilter.Users = valuesFilter.Users
 	} else {
 		defaultFilter.Queues = utils.Intersect(valuesFilter.Queues, auths.Queues, "queues")
 		defaultFilter.Groups = utils.Intersect(valuesFilter.Groups, auths.Groups, "groups")
-		defaultFilter.Agents = utils.Intersect(valuesFilter.Agents, auths.Agents, "agents")
 		defaultFilter.Users = utils.Intersect(valuesFilter.Users, auths.Users, "extensions")
 	}
 

--- a/api/methods/queries.go
+++ b/api/methods/queries.go
@@ -193,14 +193,6 @@ func GetGraphData(c *gin.Context) {
 				filter.Queues = mixedQueues
 			}
 
-			// check which queried agents are in authorized agents
-			mixedAgents := utils.Intersect(filter.Agents, auths.Agents, "")
-			if len(mixedAgents) == 0 {
-				filter.Agents = auths.Agents
-			} else {
-				filter.Agents = mixedAgents
-			}
-
 		} else if report == "cdr" {
 
 			// differ cdr authorizations by section and view

--- a/api/methods/queries.go
+++ b/api/methods/queries.go
@@ -179,12 +179,6 @@ func GetGraphData(c *gin.Context) {
 				return
 			}
 
-			// check authorized agents list
-			if len(auths.Agents) == 0 {
-				c.JSON(http.StatusBadRequest, gin.H{"message": "error executing SQL query", "status": "no allowed agents found"})
-				return
-			}
-
 			// check which queried queues are in authorized queues
 			mixedQueues := utils.Intersect(filter.Queues, auths.Queues, "")
 			if len(mixedQueues) == 0 {


### PR DESCRIPTION
The authorization to the data is already provided by the control on the queues, the control on the agents is bypassed in order not to lose deleted agents