### PR TITLE
Remove wrong recallTime column in data_call table

### DIFF
--- a/root/etc/e-smith/events/actions/nethvoice-report-conf
+++ b/root/etc/e-smith/events/actions/nethvoice-report-conf
@@ -93,6 +93,16 @@ if [[ ! -z $TABLE_EXISTS ]]; then
     if [[ $EXISTS == "" ]]; then
         /usr/bin/mysql --defaults-file=/root/.my.cnf asteriskcdrdb -e "ALTER TABLE data_call ADD COLUMN recall_time decimal(23,0) DEFAULT NULL"
     fi
+    EXISTS=$(/usr/bin/mysql --defaults-file=/root/.my.cnf asteriskcdrdb -e "SHOW COLUMNS FROM data_call LIKE 'recallTime'")
+    if [[ ! -z $EXISTS ]]; then
+        # Drop table if recallTime column exists
+        /usr/bin/mysql --defaults-file=/root/.my.cnf asteriskcdrdb -e "DROP TABLE data_call"
+        # Recreate data_call
+        FILE=/opt/nethvoice-report/api/views/data_call.sql
+        if [[ -f $FILE ]]; then
+            /usr/bin/mysql --defaults-file=/root/.my.cnf asteriskcdrdb < $FILE
+        fi
+    fi
 fi
 
 # Recreate data_call table over night if agents field is missing or is in the wrong order

--- a/root/opt/nethvoice-report/api/views/data_call.sql
+++ b/root/opt/nethvoice-report/api/views/data_call.sql
@@ -47,7 +47,7 @@ SELECT
     duration AS duration,
     ACTION AS result,
     IF(data4 > 0, 'YES', 'NO') AS recalled,
-    data4 AS recallTime
+    data4 AS recall_time
 FROM
     report_queue
 GROUP BY period, report_queue.cid, qname


### PR DESCRIPTION
Issue: nethesis/dev#6195

All the new installation from this commit https://github.com/nethesis/nethvoice-report/commit/307baf4728f907896491fd7d9dfeb6c9e8e6e70b have a wrong column recallTime  inside the data_call table.

The column name is different from the related insert that may add new data to the table.

If after the first installation the ```signal-event nethvoice-report-update``` is never run happens that the expected column recall_time is never find and every execution of the tasks logs an error like this:
```
/opt/nethvoice-report/tasks/tasks views
[ERROR]: FATAL: Error reading views directory: Error in query execution: /opt/nethvoice-report/api/views/data_call.sql: Error 1054: Unknown column 'recall_time' in 'field list
```
Data from Apr 19 or from the most recent first installation can be extracted and added to the data_call table so the solution is to drop the table if recallTime exists and to recreate it with the entire data and the right name of the column.
