### PR TITLE
Go containerized build

### DIFF
--- a/.github/workflows/make-rpms.yml
+++ b/.github/workflows/make-rpms.yml
@@ -33,12 +33,6 @@ jobs:
             AUTOBUILD_SECRET=${{ secrets.autobuild_secret }}
             AUTOBUILD_SECRET_URL=${{ secrets.autobuild_secret_url }}
           EOF
-      - name: Install additional software
-        run: |
-          sudo apt-get update
-          sudo apt-get install \
-            librrd-dev \
-            libpam0g-dev
       - name: Run prep-sources.
         run: bash prep-sources
       - name: Build RPM and publish

--- a/api/.containerignore
+++ b/api/.containerignore
@@ -1,0 +1,1 @@
+README.md

--- a/api/Containerfile
+++ b/api/Containerfile
@@ -1,0 +1,14 @@
+FROM docker.io/golang:1.18.10
+# Setup image
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y librrd-dev libpam0g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# Download dependencies
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+# Build the binary
+COPY . .
+RUN go build

--- a/prep-sources
+++ b/prep-sources
@@ -24,10 +24,10 @@ rm -rf dist/tasks
 # Build UI
 #
 pushd ui
-buildah build --rm --layers --jobs "$(nproc)" --tag nethesis/nethvoice-report-ui
-dist_container="$(podman run --rm -d nethesis/nethvoice-report-ui:latest tail -f /dev/null)"
-podman cp "$dist_container":/app/dist dist
-podman stop -t 0 "$dist_container"
+buildah build --force-rm --layers --jobs "$(nproc)" --tag nethesis/nethvoice-report-ui
+ui_container="$(podman run --rm -d nethesis/nethvoice-report-ui:latest tail -f /dev/null)"
+podman cp "$ui_container":/app/dist dist
+podman stop -t 0 "$ui_container"
 tar cvzf ui.tar.gz -C dist .
 cp ui.tar.gz ../dist/
 popd
@@ -36,9 +36,10 @@ popd
 # Build API
 #
 pushd api
-unset GOPATH
-GO111MODULE=on
-go build
+buildah build --force-rm --layers --jobs "$(nproc)" --tag nethesis/nethvoice-report-api
+api_container="$(podman run --rm -d nethesis/nethvoice-report-api:latest tail -f /dev/null)"
+podman cp "$api_container":/app/api api
+podman stop -t 0 "$api_container"
 cp api ../dist/
 popd
 
@@ -46,8 +47,9 @@ popd
 # Build Tasks
 #
 pushd tasks
-unset GOPATH
-GO111MODULE=on
-go build
+buildah build --force-rm --layers --jobs "$(nproc)" --tag nethesis/nethvoice-report-tasks
+tasks_container="$(podman run --rm -d nethesis/nethvoice-report-tasks:latest tail -f /dev/null)"
+podman cp "$tasks_container":/app/tasks tasks
+podman stop -t 0 "$tasks_container"
 cp tasks ../dist/
 popd

--- a/tasks/.containerignore
+++ b/tasks/.containerignore
@@ -1,0 +1,1 @@
+README.md

--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -1,0 +1,14 @@
+FROM docker.io/golang:1.18.10
+# Setup image
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y librrd-dev libpam0g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# Download dependencies
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+# Build the binary
+COPY . .
+RUN go build


### PR DESCRIPTION
~~Static building seems to not work due to a common dependency needed for both packages.
The culprit dependency is [github.com/ziutek/rrd](https://pkg.go.dev/github.com/ziutek/rrd), it seems there's no tag to give to the compiler to exclude this dependency from static building. Any ideas?~~

Due to latest findings by @SebastianMB-IT, it's the GoLang builder version that breaks the library dependency, locking container builder to `1.18.10`.