### PR TITLE
feat(api): allow DB timeout to be set via env

### DIFF
--- a/api/source/source.go
+++ b/api/source/source.go
@@ -24,6 +24,7 @@ package source
 
 import (
 	"database/sql"
+	"os"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -63,7 +64,13 @@ func CDRInit() *sql.DB {
 	uri := configuration.Config.CDRDatabase.User + ":" + configuration.Config.CDRDatabase.Password + "@tcp(" + configuration.Config.CDRDatabase.Host + ":" + configuration.Config.CDRDatabase.Port + ")/" + configuration.Config.CDRDatabase.Name
 
 	// connect to database with timeout and connection settings
-	db, err := sql.Open("mysql", uri+"?charset=utf8&parseTime=True&multiStatements=true&timeout=300s&readTimeout=300s&writeTimeout=300s")
+	timeout := os.Getenv("REPORTS_DB_TIMEOUT")
+	if timeout == "" {
+		timeout = "300s"
+	}
+
+	// connect to database with timeout and connection settings
+	db, err := sql.Open("mysql", uri+"?charset=utf8&parseTime=True&multiStatements=true&timeout="+timeout+"&readTimeout="+timeout+"&writeTimeout="+timeout)
 
 	// handle error
 	if err != nil {


### PR DESCRIPTION
Enhance CDRInit by checking REPORTS_DB_TIMEOUT from the environment
before establishing database connection. If unset, 300s remains as the
default timeout value for connect, read, and write operations.
