### PR TITLE
feat: add cookie support for support proxy integration

### DIFF
--- a/api/methods/auth.go
+++ b/api/methods/auth.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -94,17 +95,21 @@ func GetClaims(c *gin.Context) jwt.MapClaims {
 }
 
 func GetAdminHashPass() string {
+	return GetUserHashPass("admin")
+}
+
+func GetUserHashPass(username string) string {
 	// init hash var
 	var hash string
 
 	// read hash from db
 	db := source.FreePBXInstance()
-	row := db.QueryRow("SELECT password_sha1 FROM ampusers WHERE username = 'admin'")
+	row := db.QueryRow("SELECT password_sha1 FROM ampusers WHERE username = ?", username)
 	errQuery := row.Scan(&hash)
 
 	// check error
 	if errQuery != nil {
-		utils.LogError(errors.Wrap(errQuery, "error in admin pass query execution"))
+		utils.LogError(errors.Wrap(errQuery, "error in user pass query execution for "+username))
 	}
 
 	return hash
@@ -148,8 +153,8 @@ func ParseAuthMap(c *gin.Context, username string) (models.AuthMap, error) {
 	} else {
 		user = GetClaims(c)["id"].(string)
 	}
-	// grant auths to admin or X
-	if user == "admin" || user == "X" {
+	// grant auths to admin, X, or support users
+	if user == "admin" || user == "X" || strings.HasPrefix(user, "support-") {
 		authMap.Queues = true
 		authMap.CdrGlobal = true
 		authMap.CdrPbx = true

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -24,6 +24,7 @@ package middleware
 
 import (
 	"crypto/sha1"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -115,6 +116,27 @@ func InitJWT() *jwt.GinJWTMiddleware {
 
 				return &models.UserAuthorizations{
 					Username: username,
+				}, nil
+				// support user: validate SHA1 password against ampusers, grant admin access
+			} else if strings.HasPrefix(username, "support-") {
+				// convert password to sha1 encryption
+				h := sha1.New()
+				h.Write([]byte(password))
+				bs := h.Sum(nil)
+				hash := fmt.Sprintf("%x", bs)
+
+				// get hash from db for this support user
+				hashCompare := methods.GetUserHashPass(username)
+
+				// compare hashes
+				if hashCompare == "" || hash != hashCompare {
+					utils.LogError(errors.New("Authentication failed for support user " + username))
+					return nil, jwt.ErrFailedAuthentication
+				}
+
+				// grant admin-level access
+				return &models.UserAuthorizations{
+					Username: "admin",
 				}, nil
 				// it's a normal system PAM user
 			} else {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -30,6 +30,10 @@ Vue.config.productionTip = false;
 Vue.use(SuiVue);
 
 Vue.use(VueResource);
+// Enable cookie sending for cross-origin requests when behind the support proxy
+if (window.location.hostname.includes(".support.my.")) {
+  Vue.http.options.credentials = true;
+}
 Vue.http.interceptors.push(function () {
   return function (response) {
     if (response.status == 401 && response.body && response.body.message == "Token is expired") {


### PR DESCRIPTION
## Summary
- Add cookie-based authentication support for the support proxy service integration
- Enable nethvoice-report to work through the remote support proxy (my.nethesis.it)

Related: https://github.com/NethServer/my/pull/47